### PR TITLE
[POC] liberalize access to inviting people to the org

### DIFF
--- a/lib/github-client.js
+++ b/lib/github-client.js
@@ -3,6 +3,7 @@
 const GitHub = require('github')
 
 const githubClient = new GitHub({
+  debug: require('debug')('github').enabled,
   version: '3.0.0',
   protocol: 'https',
   host: 'api.github.com',
@@ -15,6 +16,13 @@ const githubClient = new GitHub({
 githubClient.authenticate({
   type: 'oauth',
   token: process.env.GITHUB_TOKEN
+})
+
+// store/cache info about the authenticated user
+githubClient.user.get({}, (error, user) => {
+  if (error) return console.error(error)
+  console.log('authenticated as:', user.login)
+  githubClient.user = user
 })
 
 module.exports = githubClient

--- a/package.json
+++ b/package.json
@@ -15,9 +15,11 @@
     "body-parser": "^1.15.0",
     "debug": "^2.2.0",
     "dotenv": "^2.0.0",
+    "effd": "^1.4.8",
     "express": "^4.13.4",
     "github": "^0.2.4",
     "glob": "^7.0.3",
+    "mentions-regex": "^2.0.3",
     "travis-ci": "^2.1.0"
   },
   "devDependencies": {

--- a/scripts/manage-members.js
+++ b/scripts/manage-members.js
@@ -1,0 +1,168 @@
+'use strict'
+
+require('dotenv').load({ silent: true })
+
+const ƒ = require('effd')
+const request = require('request')
+const debug = require('debug')('manage-members')
+const githubClient = require('../lib/github-client.js')
+const github = {
+  issues: ƒ.promisify(githubClient.issues),
+  pullRequests: ƒ.promisify(githubClient.pullRequests),
+  orgs: ƒ.promisify(githubClient.orgs)
+}
+
+// we need this RegExp to have the global flag
+const mentionsRegex = new RegExp(require('mentions-regex')().source, 'g')
+const exclude = (a, b) => a.filter((x) => !b.find((y) => y === x))
+const error = (e) => typeof e === 'string' ? debug(e) : console.error(e)
+const findREADME = (array) => array.find((name) => /readme.md/i.test(name))
+
+module.exports = function (app) {
+  app.on('push', (event, org, repo) => {
+    const head = event.head_commit
+    const readme = findREADME(head.modified) || findREADME(head.added)
+    if (!readme) return
+
+    download(`https://github.com/${org}/${repo}/raw/${head.id}/${readme}`)
+    .then((content) =>
+      findChangedMembers(org, repo, content)
+    )
+    .then((changes) =>
+      updateMembers(org, changes) || ƒ.reject('No members changed')
+    )
+    .catch(error)
+  })
+
+  app.on('pull_request.opened', comment)
+  app.on('pull_request.synchronize', comment)
+
+  app.on('pull_request.assigned', (event, user, repo) => {
+    if (event.assignee.login !== githubClient.user.login) return
+
+    const number = event.number
+    github.issues.edit({ user, repo, number, assignee: '' })
+    .catch(console.error)
+
+    comment(event, user, repo)
+  })
+}
+
+function updateMembers (org, changes) {
+  debug('updateMembers %s %j', org, changes)
+  if (!changes.added.length && !changes.removed.length) return
+
+  return ƒ.all([].concat(
+    changes.added.map((user) =>
+      github.orgs.addTeamMembership({ id: changes.id, user }).catch(error)
+    ),
+    changes.removed.map((user) =>
+      github.orgs.deleteTeamMember({ id: changes.id, user }).catch(error)
+  )))
+}
+
+function comment (event, user, repo) {
+  var number = event.number
+  debug('comment %s %s %s', user, repo, number)
+  return (
+    getREADME(user, repo, number)
+    .then((readme) =>
+      findChangedMembers(user, repo, readme)
+    )
+    .then((changes) =>
+      createMessage(user, changes) || ƒ.reject('No members changed')
+    )
+    .then((message) =>
+      findExistingComment(user, repo, number)
+      .then((comment) =>
+        comment
+          ? github.issues.editComment({ user, repo, id: comment.id, body: message + updated() })
+          : github.issues.createComment({ user, repo, number, body: message }) // TODO: test this path
+      )
+    )
+    .then((comment) => { debug('comment posted') })
+    .catch(error)
+  )
+}
+
+function updated () {
+  return `\n<sub>updated on ${new Date().toISOString()}</sub>`
+}
+
+function getREADME (org, repo, number) {
+  debug('getREADME %s %s %d', org, repo, number)
+
+  return github.pullRequests.getFiles({ user: org, repo, number, per_page: 100 })
+  .then((files) =>
+    files.find((file) => /^README.md$/i.test(file.filename)) || ƒ.reject('Not Applicable')
+  )
+  .then((readme) =>
+    download(readme.raw_url)
+  )
+}
+
+function findChangedMembers (org, repo, content) {
+  debug('findChangedMembers %s %s', org, repo)
+
+  const match = content.match(/<!-- team:([^ ]+).+([^<]+)<!-- team/)
+  if (!match) return ƒ.reject('Members section not found')
+
+  const name = match[1]
+  const mentions = match[2].match(mentionsRegex).map((mention) => mention.substr(2).toLocaleLowerCase())
+
+  return (
+    github.orgs.getTeams({ org, per_page: 100 })
+    .then((teams) =>
+      teams.find((t) => t.name === name) || ƒ.error('Team Not Found: ' + name)
+    )
+    .then((team) =>
+      github.orgs.getTeamMembers({ id: team.id, per_page: 100 })
+      .then((members) =>
+        members.map((member) => member.login.toLocaleLowerCase())
+      )
+      .then((members) => ({
+        id: team.id,
+        team: name,
+        added: exclude(mentions, members),
+        removed: exclude(members, mentions)
+      }))
+    )
+  )
+}
+
+function download (url) {
+  debug('downloading %s', url)
+  return ƒ((Ø) => {
+    request(url, (error, response, body) => {
+      if (error) return Ø.error(error)
+      if (response.statusCode !== 200) return Ø.error(`Download Failed: ${response.statusCode} ${response.statusMessage}`)
+      Ø.done(body)
+    })
+  })
+}
+
+function createMessage (org, changes) {
+  debug('createMessage %s %j', org, changes)
+  if (!changes.added.length && !changes.removed.length) return
+
+  var message = `This merge, if accepted, will cause changes to the @${org}/${changes.team} team.\n`
+  if (changes.added.length) {
+    message += `- Add: @${changes.added.join(', @')}\n`
+  }
+  if (changes.removed.length) {
+    message += `- Remove: @${changes.removed.join(', @')}\n`
+  }
+
+  return message
+}
+
+function findExistingComment (user, repo, number) {
+  debug('findExistingComment %s %s %d', user, repo, number)
+
+  return github.issues.getComments({ user, repo, number })
+  .then((comments) =>
+    comments.find((comment) => {
+      return comment.user.login === githubClient.user.login
+    })
+  )
+}


### PR DESCRIPTION
Here is an option for @mikeal's request to [liberalize access to inviting people to the org](https://github.com/nodejs/TSC/issues/51#issuecomment-205384492).

I created a video to show it in action:
https://www.youtube.com/watch?v=3tr4yTtHQ_g
## How it works
### Modify a repo's README.md

Place a special `<!-- team:name -->` comment in the repo's `readme.md`:

``` markdown
## Members
<!-- team:website - all @mentions in this section will be added to the team by the bot -->
- @williamkapke
- @Fishrock123

<!-- team -->
```

NOTE: You must specify the team's `name` in the opening comment like shown above!
### Create/update a PR

When a PR is submitted or changes are pushed, the bot will evaluate the commit(s) for changes to the `README.md` file. If changed, it will extract the content within the `<!-- team -->` comments find all `@mentions` and do a diff with the list of current team members.
### Accept the PR

Accepting a PR sends a `push` event. So, any push- even ones outside the PR process, will get picked up by the bot.

When the bot receives the `push` event, it will do the same parsing + evaluating as when the PR was created/updated, but instead of creating a comment- it applies the additions AND removals to the team (if any).

**To be very clear...**
This means anyone with commit rights can cause people to be added or removed from the team. It should also be noted that it does not validate that the repo is owned by the team being changed. In other words, someone could change the team name to cause addition/removals _to any team in the org_. Validation could be added if this is a concern.
### Assign it to the bot!

As somewhat a proof-of-concept, I added the ability to assign the PR to the bot to cause it to re-evaluate the PR. The original comment will be updated (plus an additional timestamp) with the results.

The bot will unassign itself when finished.
