### PR TITLE
Cleanup: disable Travis for test-github-bot repo

### DIFF
--- a/scripts/display-travis-status.js
+++ b/scripts/display-travis-status.js
@@ -2,7 +2,7 @@
 
 const debug = require('debug')('display_travis_status')
 const pollTravis = require('../lib/pollTravis')
-const enabledRepos = ['citgm', 'readable-stream', 'nodejs.org', 'test-github-bot', 'docker-node']
+const enabledRepos = ['citgm', 'readable-stream', 'nodejs.org', 'docker-node']
 
 module.exports = function (app) {
   app.on('pull_request.opened', handlePrUpdate)


### PR DESCRIPTION
As we haven't been using the [TestOrgPleaseIgnore/test-github-bot](https://github.com/TestOrgPleaseIgnore/test-github-bot) repo for testing lately, there's no need to have Travis enabled for it.

This could probably be improved by using an environment variable instead, as this is purely configuration.