### PR TITLE
Add docs required by TSC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+Welcome! Thanks for your interest in contributing to the Node.js GitHub Bot. If you'd like to report a 
+bug or suggest a feature, please [file an issue](https://github.com/nodejs/github-bot/issues).
+
+### Code of Conduct
+
+The [Node.js Code of Conduct][] applies to this project.
+
+[Node.js Code of Conduct]: https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md
+
+## Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+* (a) The contribution was created in whole or in part by me and I
+  have the right to submit it under the open source license
+  indicated in the file; or
+
+* (b) The contribution is based upon previous work that, to the best
+  of my knowledge, is covered under an appropriate open source
+  license and I have the right under that license to submit that
+  work with modifications, whether created in whole or in part
+  by me, under the same open source license (unless I am
+  permitted to submit under a different license), as indicated
+  in the file; or
+
+* (c) The contribution was provided directly to me by some other
+  person who certified (a), (b) or (c) and I have not modified
+  it.
+
+* (d) I understand and agree that this project and the contribution
+  are public and that a record of the contribution (including all
+  personal information I submit with it, including my sign-off) is
+  maintained indefinitely and may be redistributed consistent with
+  this project or the open source license(s) involved.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,5 @@
+# Node.js GitHub Bot Project Governance
+
+The Node.js GitHub Bot is overseen by the Node.js Technical Steering Committee.
+https://github.com/nodejs/TSC
+

--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,0 +1,18 @@
+The MIT License (MIT)
+=====================
+
+Copyright (c) 2016 Node.js Github Bot contributors
+--------------------------------------------------
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
+the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
+to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of 
+the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO 
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Node.js GitHub Bot
 
 The Node.js Foundation's uses this bot to help manage [the repositories of the GitHub organization](https://github.com/nodejs). 
-It executes [scripts](https://github.com/nodejs-github-bot/github-bot/tree/master/scripts) in response to events that are 
+It executes [scripts](https://github.com/nodejs/github-bot/tree/master/scripts) in response to events that are 
 pushed to it via GitHub webhooks. All [repositories](https://github.com/nodejs) that use this bot have the same webhook url & 
 secret configured (there is only 1 bot instance). Org-wide webhooks are not allow.
 
 ## Contributing
 
 Please do, contributions are more than welcome!
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### Environment Variables
 
@@ -64,4 +65,4 @@ $ npm start ./scripts/my-new-event-handler.js
 
 ## License
 
-MIT
+[MIT](LICENSE.md)


### PR DESCRIPTION
[As promised](https://github.com/nodejs/TSC/issues/117#issuecomment-237924423) in the [2016-08-11 TSC meeting](https://github.com/nodejs/TSC/issues/127) , here are the boilerplate docs required by the TSC for repos entering the Node.js GitHub org.
