### PR TITLE
jenkins: finding correct PR commit SHA and new endpoints

### DIFF
--- a/lib/push-jenkins-update.js
+++ b/lib/push-jenkins-update.js
@@ -2,20 +2,81 @@
 
 const githubClient = require('./github-client')
 
-function push (options, build) {
+function pushStarted (options, build) {
+  const pr = findPrInRef(build.ref)
+
   // create unique logger which is easily traceable for every subsequent log statement
-  const traceFields = { commit: build.commit, job: build.identifier, status: build.status }
+  const traceFields = { pr, job: build.identifier, status: build.status }
   const logger = options.logger.child(traceFields, true)
 
-  const statusOpts = Object.assign({
-    sha: build.commit,
-    url: build.url,
-    context: build.identifier,
-    state: build.status,
-    message: build.message
-  }, options)
+  const optsWithPr = Object.assign({ pr }, options)
 
-  createGhStatus(statusOpts, logger)
+  findLatestCommitInPr(optsWithPr, (err, latestCommit) => {
+    if (err) {
+      return logger.error(err, 'Got error when retrieving GitHub commits for PR')
+    }
+
+    const statusOpts = Object.assign({
+      sha: latestCommit.sha,
+      url: build.url,
+      context: build.identifier,
+      state: build.status,
+      message: build.message || 'running tests'
+    }, options)
+
+    createGhStatus(statusOpts, logger)
+  })
+}
+
+function pushEnded (options, build) {
+  const pr = findPrInRef(build.ref)
+
+  // create unique logger which is easily traceable for every subsequent log statement
+  const traceFields = { pr, job: build.identifier, status: build.status }
+  const logger = options.logger.child(traceFields, true)
+
+  const optsWithPr = Object.assign({ pr }, options)
+
+  findLatestCommitInPr(optsWithPr, (err, latestCommit) => {
+    if (err) {
+      return logger.error(err, 'Got error when retrieving GitHub commits for PR')
+    }
+
+    const statusOpts = Object.assign({
+      sha: latestCommit.sha,
+      url: build.url,
+      context: build.identifier,
+      state: build.status,
+      message: build.message || 'all tests passed'
+    }, options)
+
+    createGhStatus(statusOpts, logger)
+  })
+}
+
+function findPrInRef (gitRef) {
+  // refs/pull/12345/head
+  return gitRef.split('/')[2]
+}
+
+function findLatestCommitInPr (options, cb) {
+  githubClient.pullRequests.getCommits({
+    user: options.owner,
+    repo: options.repo,
+    number: options.pr
+  }, (err, commitMetas) => {
+    if (err) {
+      return cb(err)
+    }
+
+    const lastCommitMeta = commitMetas.pop()
+    const lastCommit = {
+      sha: lastCommitMeta.sha,
+      date: lastCommitMeta.commit.committer.date
+    }
+
+    cb(null, lastCommit)
+  })
 }
 
 function createGhStatus (options, logger) {
@@ -41,4 +102,5 @@ function validate (payload) {
 }
 
 exports.validate = validate
-exports.push = push
+exports.pushStarted = pushStarted
+exports.pushEnded = pushEnded

--- a/scripts/node-jenkins-status.js
+++ b/scripts/node-jenkins-status.js
@@ -3,14 +3,30 @@
 const pushJenkinsUpdate = require('../lib/push-jenkins-update')
 
 module.exports = function (app) {
-  app.post('/node/jenkins', (req, res) => {
+  app.post('/node/jenkins/start', (req, res) => {
     const isValid = pushJenkinsUpdate.validate(req.body)
 
     if (!isValid) {
       return res.status(400).end('Invalid payload')
     }
 
-    pushJenkinsUpdate.push({
+    pushJenkinsUpdate.pushStarted({
+      owner: 'nodejs',
+      repo: 'node',
+      logger: req.log
+    }, req.body)
+
+    res.status(201).end()
+  })
+
+  app.post('/node/jenkins/end', (req, res) => {
+    const isValid = pushJenkinsUpdate.validate(req.body)
+
+    if (!isValid) {
+      return res.status(400).end('Invalid payload')
+    }
+
+    pushJenkinsUpdate.pushEnded({
       owner: 'nodejs',
       repo: 'node',
       logger: req.log

--- a/test/_fixtures/error-payload.json
+++ b/test/_fixtures/error-payload.json
@@ -3,5 +3,6 @@
     "status": "failure",
     "message": "tests failed",
     "commit": "8a5fec2a6bade91e544a30314d7cf21f8a200de1",
-    "url": "https://ci.nodejs.org/job/node-test-commit-arm/3087/"
+    "url": "https://ci.nodejs.org/job/node-test-commit-arm/3087/",
+    "ref": "refs/pull/12345/head"
 }

--- a/test/_fixtures/invalid-payload.json
+++ b/test/_fixtures/invalid-payload.json
@@ -1,5 +1,6 @@
 {
     "identifier": "test/osx",
     "status": "pending",
-    "url": "https://ci.nodejs.org/job/node-test-commit-osx/3157/"
+    "url": "https://ci.nodejs.org/job/node-test-commit-osx/3157/",
+    "ref": "refs/pull/12345/head"
 }

--- a/test/_fixtures/pending-payload.json
+++ b/test/_fixtures/pending-payload.json
@@ -3,5 +3,6 @@
     "status": "pending",
     "message": "checking for errors",
     "commit": "8a5fec2a6bade91e544a30314d7cf21f8a200de1",
-    "url": "https://ci.nodejs.org/job/node-test-commit-linux/3176/"
+    "url": "https://ci.nodejs.org/job/node-test-commit-linux/3176/",
+    "ref": "refs/pull/12345/head"
 }

--- a/test/_fixtures/pr-commits.json
+++ b/test/_fixtures/pr-commits.json
@@ -1,0 +1,77 @@
+[
+  {
+    "url": "https://api.github.com/repos/octocat/Hello-World/commits/8a5fec2a6bade91e544a30314d7cf21f8a200de1",
+    "sha": "8a5fec2a6bade91e544a30314d7cf21f8a200de1",
+    "html_url": "https://github.com/octocat/Hello-World/commit/8a5fec2a6bade91e544a30314d7cf21f8a200de1",
+    "comments_url": "https://api.github.com/repos/octocat/Hello-World/commits/8a5fec2a6bade91e544a30314d7cf21f8a200de1/comments",
+    "commit": {
+      "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/8a5fec2a6bade91e544a30314d7cf21f8a200de1",
+      "author": {
+        "name": "Monalisa Octocat",
+        "email": "support@github.com",
+        "date": "2011-04-14T16:00:49Z"
+      },
+      "committer": {
+        "name": "Monalisa Octocat",
+        "email": "support@github.com",
+        "date": "2011-04-14T16:00:49Z"
+      },
+      "message": "Fix all the bugs",
+      "tree": {
+        "url": "https://api.github.com/repos/octocat/Hello-World/tree/8a5fec2a6bade91e544a30314d7cf21f8a200de1",
+        "sha": "8a5fec2a6bade91e544a30314d7cf21f8a200de1"
+      },
+      "comment_count": 0,
+      "verification": {
+        "verified": true,
+        "reason": "valid",
+        "signature": "-----BEGIN PGP MESSAGE-----\n...\n-----END PGP MESSAGE-----",
+        "payload": "tree 8a5fec2a6bade91e544a30314d7cf21f8a200de1\n..."
+      }
+    },
+    "author": {
+      "login": "octocat",
+      "id": 1,
+      "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/octocat",
+      "html_url": "https://github.com/octocat",
+      "followers_url": "https://api.github.com/users/octocat/followers",
+      "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+      "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+      "organizations_url": "https://api.github.com/users/octocat/orgs",
+      "repos_url": "https://api.github.com/users/octocat/repos",
+      "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/octocat/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "octocat",
+      "id": 1,
+      "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/octocat",
+      "html_url": "https://github.com/octocat",
+      "followers_url": "https://api.github.com/users/octocat/followers",
+      "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+      "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+      "organizations_url": "https://api.github.com/users/octocat/orgs",
+      "repos_url": "https://api.github.com/users/octocat/repos",
+      "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/octocat/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "url": "https://api.github.com/repos/octocat/Hello-World/commits/8a5fec2a6bade91e544a30314d7cf21f8a200de1",
+        "sha": "8a5fec2a6bade91e544a30314d7cf21f8a200de1"
+      }
+    ]
+  }
+]

--- a/test/_fixtures/success-payload.json
+++ b/test/_fixtures/success-payload.json
@@ -3,5 +3,6 @@
     "status": "success",
     "message": "tests passed",
     "commit": "8a5fec2a6bade91e544a30314d7cf21f8a200de1",
-    "url": "https://ci.nodejs.org/job/node-test-commit-osx/3157/"
+    "url": "https://ci.nodejs.org/job/node-test-commit-osx/3157/",
+    "ref": "refs/pull/12345/head"
 }


### PR DESCRIPTION
This introduces the bot finding the correct commit SHAs to use for core PRs, rather than trusting Jenkins to provide SHAs, mainly due to rebasing we often do when running PR jobs.

Also refactored the endpoint Jenkins pushes updates, from one single endpoint to `/node/jenkins/{start,end}`.

P.S. this has been tested in production for a while, and worked pretty well.

/cc @jbergstroem 