### PR TITLE
labels: stricter version match in base branch

### DIFF
--- a/lib/node-labels.js
+++ b/lib/node-labels.js
@@ -70,7 +70,7 @@ function resolveLabels (filepathsChanged, baseBranch, limitLib = true) {
                   : matchAllSubSystem(filepathsChanged, limitLib)
 
   // Add version labels if PR is made against a version branch
-  const m = /^(v\d+\.(?:\d+|x))(?:-|$)/.exec(baseBranch)
+  const m = /^(v\d+\.(?:\d+|x))(?:-staging|$)/.exec(baseBranch)
   if (m) {
     labels.push(m[1])
   }


### PR DESCRIPTION
Minor adjustment to the regex matching the base branch a PR is targeted against.

Refs https://github.com/nodejs/github-bot/pull/55#discussion_r77553358

/cc @Fishrock123 