### PR TITLE
labels: defer resolving labels

### DIFF
--- a/lib/node-repo.js
+++ b/lib/node-repo.js
@@ -4,6 +4,11 @@ const githubClient = require('./github-client')
 
 const resolveLabels = require('./node-labels').resolveLabels
 
+function deferredResolveLabelsThenUpdatePr (options) {
+  const timeoutMillis = (options.timeoutInSec || 0) * 1000
+  setTimeout(resolveLabelsThenUpdatePr, timeoutMillis, options)
+}
+
 function resolveLabelsThenUpdatePr (options) {
   githubClient.pullRequests.getFiles({
     user: options.owner,
@@ -40,4 +45,4 @@ function updatePrWithLabels (options, labels) {
   })
 }
 
-exports.resolveLabelsThenUpdatePr = resolveLabelsThenUpdatePr
+exports.resolveLabelsThenUpdatePr = deferredResolveLabelsThenUpdatePr

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "eventsource": "^0.2.1",
+    "lolex": "^1.5.1",
     "nock": "^8.0.0",
     "nodemon": "^1.9.1",
     "proxyquire": "^1.7.10",

--- a/scripts/node-subsystem-label.js
+++ b/scripts/node-subsystem-label.js
@@ -24,7 +24,8 @@ module.exports = function (app) {
       repo,
       prId,
       logger,
-      baseBranch
+      baseBranch,
+      timeoutInSec: 2
     })
   }
 }


### PR DESCRIPTION
These changes defer the process of label resolving
to prevent 404 errors from Github API

Closes https://github.com/nodejs/github-bot/issues/79