### PR TITLE
Fix running individual scripts with `npm start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ When developing a script, it is likely that you will only want to run the script
 pass an additional [glob](https://www.npmjs.com/package/glob) argument to specify which scripts to run.
 
 ```bash
-$ npm start ./scripts/my-new-event-handler.js
+$ SCRIPTS=./scripts/my-new-event-handler.js npm start
 ```
 
 

--- a/app.js
+++ b/app.js
@@ -15,6 +15,8 @@ const captureRaw = (req, res, buffer) => { req.raw = buffer }
 
 const app = express()
 
+const scriptsToLoad = process.env.SCRIPTS || './scripts/**/*.js'
+
 app.use(bodyParser.json({ verify: captureRaw }))
 app.use('/logs', authMiddleware, express.static(path.join(__dirname, 'logs')))
 // bunyanMiddleware gives us request id's and unique loggers per incoming request,
@@ -24,7 +26,7 @@ app.use(bunyanMiddleware({ logger, obscureHeaders: ['x-hub-signature'] }))
 require('./lib/github-events')(app)
 
 // load all the files in the scripts folder
-glob.sync(process.argv[2] || './scripts/**/*.js').forEach((file) => {
+glob.sync(scriptsToLoad).forEach((file) => {
   logger.info('Loading:', file)
   require(file)(app)
 })


### PR DESCRIPTION
When introducing traceable logs and bunyan in PR #42, it broke the possibility of providing individual scripts to run as second argument to `npm start`.

This fixes that by allowing scripts to be passed in as an environment variables, instead of a CLI argument to `app.js`.

Refs https://github.com/nodejs/github-bot/pull/42

/cc @Fishrock123 