### PR TITLE
fetch multiple pages of labels if necessary

### DIFF
--- a/lib/node-repo.js
+++ b/lib/node-repo.js
@@ -92,7 +92,7 @@ function fetchExistingLabels (options, cb) {
     return cb(null, existingLabelsCache.get(cacheKey))
   }
 
-  fetchAllLabelsFromPage(options, 1, (err, existingLabels) => {
+  fetchLabelPages(options, 1, (err, existingLabels) => {
     if (err) {
       return cb(err)
     }
@@ -107,7 +107,7 @@ function fetchExistingLabels (options, cb) {
   })
 }
 
-function fetchAllLabelsFromPage (options, startPageNum, cb) {
+function fetchLabelPages (options, startPageNum, cb) {
   // the github client API is somewhat misleading,
   // this fetches *all* repo labels not just for an issue
   githubClient.issues.getLabels({
@@ -122,7 +122,7 @@ function fetchAllLabelsFromPage (options, startPageNum, cb) {
     if (!githubClient.hasNextPage(existingLabels)) {
       return cb(null, existingLabels)
     }
-    fetchAllLabelsFromPage(
+    fetchLabelPages(
       options,
       startPageNum + 1,
       (err, remainingLabels) => err ? cb(err) : cb(null, existingLabels.concat(remainingLabels))

--- a/lib/node-repo.js
+++ b/lib/node-repo.js
@@ -92,8 +92,6 @@ function fetchExistingLabels (options, cb) {
     return cb(null, existingLabelsCache.get(cacheKey))
   }
 
-  // the github client API is somewhat misleading,
-  // this fetches *all* repo labels not just for an issue
   fetchAllLabelsFromPage(options, 1, (err, existingLabels) => {
     if (err) {
       return cb(err)

--- a/lib/node-repo.js
+++ b/lib/node-repo.js
@@ -94,11 +94,7 @@ function fetchExistingLabels (options, cb) {
 
   // the github client API is somewhat misleading,
   // this fetches *all* repo labels not just for an issue
-  githubClient.issues.getLabels({
-    user: options.owner,
-    repo: options.repo,
-    per_page: 100
-  }, (err, existingLabels) => {
+  fetchAllLabelsFromPage(options, 1, (err, existingLabels) => {
     if (err) {
       return cb(err)
     }
@@ -110,6 +106,29 @@ function fetchExistingLabels (options, cb) {
     options.logger.debug('Filled existing repo labels cache: ' + existingLabelNames)
 
     cb(null, existingLabelNames)
+  })
+}
+
+function fetchAllLabelsFromPage (options, startPageNum, cb) {
+  // the github client API is somewhat misleading,
+  // this fetches *all* repo labels not just for an issue
+  githubClient.issues.getLabels({
+    user: options.owner,
+    repo: options.repo,
+    page: startPageNum,
+    per_page: 100
+  }, (err, existingLabels) => {
+    if (err) {
+      return cb(err)
+    }
+    if (!githubClient.hasNextPage(existingLabels)) {
+      return cb(null, existingLabels)
+    }
+    fetchAllLabelsFromPage(
+      options,
+      startPageNum + 1,
+      (err, remainingLabels) => err ? cb(err) : cb(null, existingLabels.concat(remainingLabels))
+    )
   })
 }
 

--- a/test/_fixtures/repo-labels-page-2.json
+++ b/test/_fixtures/repo-labels-page-2.json
@@ -1,0 +1,72 @@
+[
+  {
+    "id": 280213872,
+    "url": "https://api.github.com/repos/nodejs/node/labels/v0.12",
+    "name": "v0.12",
+    "color": "c7def8",
+    "default": false
+  },
+  {
+    "id": 280213880,
+    "url": "https://api.github.com/repos/nodejs/node/labels/v4.x",
+    "name": "v4.x",
+    "color": "eb6420",
+    "default": false
+  },
+  {
+    "id": 364835500,
+    "url": "https://api.github.com/repos/nodejs/node/labels/v6.x",
+    "name": "v6.x",
+    "color": "c2e0c6",
+    "default": false
+  },
+  {
+    "id": 441404503,
+    "url": "https://api.github.com/repos/nodejs/node/labels/v7.x",
+    "name": "v7.x",
+    "color": "fbca04",
+    "default": false
+  },
+  {
+    "id": 176191361,
+    "url": "https://api.github.com/repos/nodejs/node/labels/V8",
+    "name": "V8",
+    "color": "0052cc",
+    "default": false
+  },
+  {
+    "id": 386816750,
+    "url": "https://api.github.com/repos/nodejs/node/labels/V8_inspector",
+    "name": "V8_inspector",
+    "color": "ededed",
+    "default": false
+  },
+  {
+    "id": 155436007,
+    "url": "https://api.github.com/repos/nodejs/node/labels/vm",
+    "name": "vm",
+    "color": "bfdadc",
+    "default": false
+  },
+  {
+    "id": 166236401,
+    "url": "https://api.github.com/repos/nodejs/node/labels/windows",
+    "name": "windows",
+    "color": "9944dd",
+    "default": false
+  },
+  {
+    "id": 151728680,
+    "url": "https://api.github.com/repos/nodejs/node/labels/wontfix",
+    "name": "wontfix",
+    "color": "ededed",
+    "default": true
+  },
+  {
+    "id": 155436008,
+    "url": "https://api.github.com/repos/nodejs/node/labels/zlib",
+    "name": "zlib",
+    "color": "009800",
+    "default": false
+  }
+]

--- a/test/unit/node-repo.test.js
+++ b/test/unit/node-repo.test.js
@@ -10,53 +10,85 @@ const githubClient = require('../../lib/github-client')
 const readFixture = require('../read-fixture')
 
 tap.test('fetchExistingLabels(): caches existing repository labels', (t) => {
-  const fakeGithubClient = sinon.stub(githubClient.issues, 'getLabels').yields(null, [])
+  sinon.stub(githubClient.issues, 'getLabels').yields(null, [])
+  sinon.stub(githubClient, 'hasNextPage', () => false)
   const nodeRepo = proxyquire('../../lib/node-repo', {
-    './github-client': fakeGithubClient
+    './github-client': githubClient
   })
 
   t.plan(1)
-  t.tearDown(() => githubClient.issues.getLabels.restore())
+  t.tearDown(() => {
+    githubClient.issues.getLabels.restore()
+    githubClient.hasNextPage.restore()
+  })
 
   nodeRepo._fetchExistingLabels({ owner: 'nodejs', repo: 'node', logger }, () => {
     nodeRepo._fetchExistingLabels({ owner: 'nodejs', repo: 'node', logger }, () => {
-      t.ok(fakeGithubClient.calledOnce)
+      t.ok(githubClient.issues.getLabels.calledOnce)
     })
   })
 })
 
 tap.test('fetchExistingLabels(): cache expires after one hour', (t) => {
   const clock = lolex.install()
-  const fakeGithubClient = sinon.stub(githubClient.issues, 'getLabels').yields(null, [])
+  sinon.stub(githubClient.issues, 'getLabels').yields(null, [])
+  sinon.stub(githubClient, 'hasNextPage', () => false)
   const nodeRepo = proxyquire('../../lib/node-repo', {
-    './github-client': fakeGithubClient
+    './github-client': githubClient
   })
 
   t.plan(1)
-  t.tearDown(() => githubClient.issues.getLabels.restore() && clock.uninstall())
+  t.tearDown(() => {
+    githubClient.issues.getLabels.restore()
+    githubClient.hasNextPage.restore()
+    clock.uninstall()
+  })
 
   nodeRepo._fetchExistingLabels({ owner: 'nodejs', repo: 'node', logger }, () => {
     // fetch labels again after 1 hour and 1 minute
     clock.tick(1000 * 60 * 61)
 
     nodeRepo._fetchExistingLabels({ owner: 'nodejs', repo: 'node', logger }, () => {
-      t.equal(fakeGithubClient.callCount, 2)
+      t.equal(githubClient.issues.getLabels.callCount, 2)
     })
   })
 })
 
 tap.test('fetchExistingLabels(): yields an array of existing label names', (t) => {
   const labelsFixture = readFixture('repo-labels.json')
-  const fakeGithubClient = sinon.stub(githubClient.issues, 'getLabels').yields(null, labelsFixture)
+  sinon.stub(githubClient.issues, 'getLabels').yields(null, labelsFixture)
+  sinon.stub(githubClient, 'hasNextPage', () => false)
   const nodeRepo = proxyquire('../../lib/node-repo', {
-    './github-client': fakeGithubClient
+    './github-client': githubClient
   })
 
   t.plan(2)
-  t.tearDown(() => githubClient.issues.getLabels.restore())
+  t.tearDown(() => {
+    githubClient.issues.getLabels.restore()
+    githubClient.hasNextPage.restore()
+  })
 
   nodeRepo._fetchExistingLabels({ owner: 'nodejs', repo: 'node', logger }, (err, existingLabels) => {
     t.equal(err, null)
     t.ok(existingLabels.includes('cluster'))
+  })
+})
+
+tap.test('fetchExistingLabels(): can retrieve more than 100 labels', (t) => {
+  const labelsFixturePage1 = readFixture('repo-labels.json')
+  const labelsFixturePage2 = readFixture('repo-labels-page-2.json')
+  sinon.stub(githubClient.issues, 'getLabels', (options, cb) => cb(null, options.page === 1 ? labelsFixturePage1 : labelsFixturePage2))
+  sinon.stub(githubClient, 'hasNextPage', (listing) => listing === labelsFixturePage1)
+  const nodeRepo = proxyquire('../../lib/node-repo', {'./github-client': githubClient})
+
+  t.plan(3)
+  t.tearDown(() => {
+    githubClient.issues.getLabels.restore()
+    githubClient.hasNextPage.restore()
+  })
+  nodeRepo._fetchExistingLabels({ owner: 'nodejs', repo: 'node', logger }, (err, existingLabels) => {
+    t.equal(err, null)
+    t.ok(existingLabels.includes('cluster'))
+    t.ok(existingLabels.includes('windows'))
   })
 })


### PR DESCRIPTION
This updates `fetchExistingLabels` to fetch *all* labels from GitHub, rather
than just the first 100 labels. This allows the bot to work correctly now
that the repo has more than 100 labels.

Refs: https://github.com/nodejs/node/issues/9841

Since `node-repo` now uses the `githubClient.hasNextPage()` function, this commit also updates the stubs in the corresponding tests to avoid throwing an error when that function is called.