### PR TITLE
labels: fix build label

### DIFF
--- a/lib/node-labels.js
+++ b/lib/node-labels.js
@@ -13,8 +13,8 @@ const subSystemLabelsMap = new Map([
   [/^\w+\.md$/, 'doc'],
   // different variants of *Makefile and build files
   [/^(tools\/)?(Makefile|BSDmakefile|create_android_makefiles)$/, 'build'],
-  [/^tools\/(install.py|genv8constants.py|getnodeversion.py|js2c.py|utils.py|configure.d\/.*)$/, 'build'],
-  [/^(configure|node.gyp|common.gypi|vcbuild.bat)$/, 'build'],
+  [/^tools\/(install\.py|genv8constants\.py|getnodeversion\.py|js2c\.py|utils\.py|configure\.d\/.*)$/, 'build'],
+  [/^(configure|node\.gyp|common\.gypi|vcbuild\.bat)$/, 'build'],
   // all other tools/ changes should be marked as such
   [/^tools\//, 'tools'],
 
@@ -52,7 +52,7 @@ const exclusiveLabelsMap = new Map([
   // specific map for modules.md as it should be labeled 'module' not 'modules'
   [/^doc\/api\/modules.md$/, ['doc', 'module']],
   // automatically tag subsystem-specific API doc changes
-  [/^doc\/api\/(\w+).md$/, ['doc', '$1']],
+  [/^doc\/api\/(\w+)\.md$/, ['doc', '$1']],
   [/^doc\//, 'doc'],
   [/^benchmark\//, 'benchmark']
 ])

--- a/lib/node-labels.js
+++ b/lib/node-labels.js
@@ -14,7 +14,7 @@ const subSystemLabelsMap = new Map([
   // different variants of *Makefile and build files
   [/^(tools\/)?(Makefile|BSDmakefile|create_android_makefiles)$/, 'build'],
   [/^tools\/(install.py|genv8constants.py|getnodeversion.py|js2c.py|utils.py|configure.d\/.*)$/, 'build'],
-  [/^(configure|node.gyp|common.gypi)$/, 'build'],
+  [/^(configure|node.gyp|common.gypi|vcbuild.bat)$/, 'build'],
   // all other tools/ changes should be marked as such
   [/^tools\//, 'tools'],
 

--- a/test/unit/node-labels.test.js
+++ b/test/unit/node-labels.test.js
@@ -307,3 +307,13 @@ tap.test('label: tools label', (t) => {
 
   t.end()
 })
+
+tap.test('label: build label (windows)', (t) => {
+  const labels = nodeLabels.resolveLabels([
+    'vcbuild.bat'
+  ])
+
+  t.same(labels, ['build'])
+
+  t.end()
+})


### PR DESCRIPTION
This PR fixes an issue where vcbuild.bat changes were not labeled with 'build' and an issue with some label regexps where dots in filenames were not escaped.

Ref: https://github.com/nodejs/github-bot/issues/88#issuecomment-265287236