### PR TITLE
attempt-backport: git clean -fd after checkout

### DIFF
--- a/scripts/attempt-backport.js
+++ b/scripts/attempt-backport.js
@@ -172,7 +172,11 @@ function attemptBackport (options, version, isLTS, cb) {
 
   function gitCheckout () {
     options.logger.debug(`checking out origin/v${version}.x-staging...`)
-    wrapCP('git', ['checkout', `origin/v${version}.x-staging`], gitReset)
+    wrapCP('git', ['checkout', `origin/v${version}.x-staging`], gitClean_fd)
+  }
+
+  function gitClean_fd () {
+    wrapCP('git', ['clean', '-fd'], gitReset)
   }
 
   function gitReset () {


### PR DESCRIPTION
Not 100% sure this matters but I'd rather be safe. Noticed this with some `git status` inbetween.