### PR TITLE
node-repo: refactor out fetchExistingThenUpdatePr

### DIFF
--- a/lib/node-repo.js
+++ b/lib/node-repo.js
@@ -26,16 +26,23 @@ function resolveLabelsThenUpdatePr (options) {
     const filepathsChanged = res.map((fileMeta) => fileMeta.filename)
     const resolvedLabels = resolveLabels(filepathsChanged, options.baseBranch)
 
-    fetchExistingLabels(options, (err, existingLabels) => {
-      if (err) {
-        return options.logger.error(err, 'Error retrieving existing repo labels')
-      }
+    fetchExistingThenUpdatePr(options, resolvedLabels)
+  })
+}
 
-      const labelsToAdd = stringsInCommon(existingLabels, resolvedLabels)
-      options.logger.debug('Resolved labels: ' + labelsToAdd)
+function fetchExistingThenUpdatePr (options, labels) {
+  fetchExistingLabels(options, (err, existingLabels) => {
+    if (err) {
+      options.logger.error(err, 'Error retrieving existing repo labels')
 
-      updatePrWithLabels(options, labelsToAdd)
-    })
+      updatePrWithLabels(options, labels)
+      return
+    }
+
+    const labelsToAdd = stringsInCommon(existingLabels, labels)
+    options.logger.debug('Resolved labels: ' + labelsToAdd)
+
+    updatePrWithLabels(options, labelsToAdd)
   })
 }
 


### PR DESCRIPTION
This is a precursor to two major improvements to the attempt-backport script.

Would like to get this landed tomorrow morning so I can work on having labels only add once, and also having the bot remove it's own labels when appropriate.