### PR TITLE
attempt-backport: unlabel and clean labeling

### DIFF
--- a/lib/node-repo.js
+++ b/lib/node-repo.js
@@ -180,7 +180,7 @@ function stringsInCommon (arr1, arr2) {
 
 exports.getBotPrLabels = getBotPrLabels
 exports.removeLabelFromPR = removeLabelFromPR
-exports.updatePrWithLabels = updatePrWithLabels
+exports.fetchExistingThenUpdatePr = fetchExistingThenUpdatePr
 exports.resolveLabelsThenUpdatePr = deferredResolveLabelsThenUpdatePr
 
 // exposed for testability

--- a/lib/node-repo.js
+++ b/lib/node-repo.js
@@ -137,6 +137,40 @@ function fetchLabelPages (options, startPageNum, cb) {
   })
 }
 
+function getBotPrLabels (options, cb) {
+  githubClient.issues.getEvents({
+    owner: options.owner,
+    repo: options.repo,
+    page: 1,
+    per_page: 100, // we probably won't hit this
+    issue_number: options.prId
+  }, (err, events) => {
+    if (err) {
+      return cb(err)
+    }
+
+    const ourLabels = []
+
+    for (const event of events) {
+      if (event.event === 'unlabeled') {
+        const index = ourLabels.indexOf(event.label.name)
+        if (index === -1) continue
+
+        ourLabels.splice(index, 1)
+      } else if (event.event === 'labeled') {
+        const index = ourLabels.indexOf(event.label.name)
+        if (index > -1) continue
+
+        if (event.actor.login === 'nodejs-github-bot') {
+          ourLabels.push(event.label.name)
+        }
+      }
+    }
+
+    cb(null, ourLabels)
+  })
+}
+
 function stringsInCommon (arr1, arr2) {
   const loweredArr2 = arr2.map((str) => str.toLowerCase())
   // we want the original string cases in arr1, therefore we don't lowercase them
@@ -144,6 +178,7 @@ function stringsInCommon (arr1, arr2) {
   return arr1.filter((str) => loweredArr2.indexOf(str.toLowerCase()) !== -1)
 }
 
+exports.getBotPrLabels = getBotPrLabels
 exports.removeLabelFromPR = removeLabelFromPR
 exports.updatePrWithLabels = updatePrWithLabels
 exports.resolveLabelsThenUpdatePr = deferredResolveLabelsThenUpdatePr

--- a/scripts/attempt-backport.js
+++ b/scripts/attempt-backport.js
@@ -4,7 +4,7 @@ const child_process = require('child_process')
 const debug = require('debug')('attempt-backport')
 const request = require('request')
 const node_repo = require('../lib/node-repo')
-const updatePrWithLabels = node_repo.updatePrWithLabels
+const fetchExistingThenUpdatePr = node_repo.fetchExistingThenUpdatePr
 const removeLabelFromPR = node_repo.removeLabelFromPR
 const getBotPrLabels = node_repo.getBotPrLabels
 
@@ -132,7 +132,7 @@ function attemptBackport (options, version, isLTS, cb) {
       options.logger.debug(`backport to ${version} failed`)
 
       if (!isLTS) {
-        updatePrWithLabels(options, [`dont-land-on-v${version}.x`])
+        fetchExistingThenUpdatePr(options, [`dont-land-on-v${version}.x`])
       } else {
         getBotPrLabels(options, (err, ourLabels) => {
           if (err) {
@@ -223,7 +223,7 @@ function attemptBackport (options, version, isLTS, cb) {
     const cp = wrapCP('git', ['am'], { stdio: 'pipe' }, function done () {
       // Success!
       if (isLTS) {
-        updatePrWithLabels(options, [`lts-watch-v${version}.x`])
+        fetchExistingThenUpdatePr(options, [`lts-watch-v${version}.x`])
       } else {
         // TODO(Fishrock123): Re-enable this, but do a check first
         // to make sure the label was set by the bot only.


### PR DESCRIPTION
Should fix https://github.com/nodejs/github-bot/issues/100#issuecomment-266113411 while also giving a way to see when a PR update has changed the backportability.

This was always on the plans, I just hadn't gotten to it before.

cc @phillipj and maybe also @TheAlphaNerd 

I don't really trust myself that it'l work without testing though, but I have a plan on how to test the script, so I'm going to do that next and then rebase this ontop.
