### PR TITLE
attempt-backport: simplify git steps

### DIFF
--- a/scripts/attempt-backport.js
+++ b/scripts/attempt-backport.js
@@ -167,11 +167,11 @@ function attemptBackport (options, version, isLTS, cb) {
 
   function gitCheckout () {
     options.logger.debug(`checking out origin/v${version}.x-staging...`)
-    wrapCP('git', ['checkout', `origin/v${version}.x-staging`], gitClean_fd)
+    wrapCP('git', ['checkout', `origin/v${version}.x-staging`], gitClean_fdx)
   }
 
-  function gitClean_fd () {
-    wrapCP('git', ['clean', '-fd'], fetchDiff)
+  function gitClean_fdx () {
+    wrapCP('git', ['clean', '-fdx'], fetchDiff)
   }
 
   function fetchDiff () {

--- a/scripts/attempt-backport.js
+++ b/scripts/attempt-backport.js
@@ -156,13 +156,8 @@ function attemptBackport (options, version, isLTS, cb) {
         debug(`error before exit, code: ${code}, on '${argsString}'`)
         return
       }
-      gitResetBefore()
+      gitRemoteUpdate()
     })
-  }
-
-  function gitResetBefore () {
-    options.logger.debug(`resetting origin/v${version}.x-staging...`)
-    wrapCP('git', ['reset', `origin/v${version}.x-staging`, '--hard'], gitRemoteUpdate)
   }
 
   function gitRemoteUpdate () {
@@ -176,12 +171,7 @@ function attemptBackport (options, version, isLTS, cb) {
   }
 
   function gitClean_fd () {
-    wrapCP('git', ['clean', '-fd'], gitReset)
-  }
-
-  function gitReset () {
-    options.logger.debug(`resetting origin/v${version}.x-staging...`)
-    wrapCP('git', ['reset', `origin/v${version}.x-staging`, '--hard'], fetchDiff)
+    wrapCP('git', ['clean', '-fd'], fetchDiff)
   }
 
   function fetchDiff () {


### PR DESCRIPTION
- Resetting *before* checkout is probably actually faulty logic as
described in
https://github.com/nodejs/github-bot/issues/100#issuecomment-267359637

- Resetting after checkout is unnecessary because we check out the
origin/ branch so the HEAD becomes detached.