### PR TITLE
attempt-backport: enable 3-way merge for git am

### DIFF
--- a/scripts/attempt-backport.js
+++ b/scripts/attempt-backport.js
@@ -214,7 +214,7 @@ function attemptBackport (options, version, isLTS, cb) {
 
   function gitAttemptBackport (req) {
     options.logger.debug(`attempting a backport to v${version}...`)
-    const cp = wrapCP('git', ['am'], { stdio: 'pipe' }, function done () {
+    const cp = wrapCP('git', ['am', '-3'], { stdio: 'pipe' }, function done () {
       // Success!
       if (isLTS) {
         fetchExistingThenUpdatePr(options, [`lts-watch-v${version}.x`])


### PR DESCRIPTION
We've seen a lot of patches not applied cleanly by the bot, which in fact
should have landed without trouble, at least with 3-way merges enabled.

This trivial change enables fallback to 3-way merge when a patch
doesn't apply cleanly when running `git am`.

Should we give this a try before possibly disabling the attempt-backport labels?

Refs https://github.com/nodejs/github-bot/issues/116

/cc @mscdex @MylesBorins @Fishrock123