### PR TITLE
attempt-backport: temporary disable dont-land-on-* labels

### DIFF
--- a/scripts/attempt-backport.js
+++ b/scripts/attempt-backport.js
@@ -132,7 +132,7 @@ function attemptBackport (options, version, isLTS, cb) {
       options.logger.debug(`backport to ${version} failed`)
 
       if (!isLTS) {
-        fetchExistingThenUpdatePr(options, [`dont-land-on-v${version}.x`])
+        options.logger.debug(`Should have added (but temporary disabled): dont-land-on-v${version}.x`)
       } else {
         getBotPrLabels(options, (err, ourLabels) => {
           if (err) {


### PR DESCRIPTION
There's been some concerns about auto labelling `dont-land-on-*` labels lately, especially since the bot is often wrongly adding these labels ATM. Therefore temporarily disabling that functionality to avoid further damage.

Refs https://github.com/nodejs/github-bot/issues/116