### PR TITLE
logs: configurable logs directory with $LOGS_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 - **`LOGIN_CREDENTIALS`**<br>
   Username and password used to protected the log files exposed in /logs. Expected format: `username:password`.
 - **`KEEP_LOGS`**<br>
-  Number of days to keep rotated log files in `./logs`, defaults to `10` if not set.
-
+  Number of days to keep rotated log files, defaults to `10` if not set.
+- **`LOGS_DIR`**<br>
+  Directory where logs should be written and exposed by the `/logs` endpoint.
 
 ### Developing Locally
 

--- a/app.js
+++ b/app.js
@@ -2,7 +2,6 @@
 
 require('dotenv').load({ silent: true })
 
-const path = require('path')
 const glob = require('glob')
 const express = require('express')
 const bodyParser = require('body-parser')
@@ -16,9 +15,14 @@ const captureRaw = (req, res, buffer) => { req.raw = buffer }
 const app = express()
 
 const scriptsToLoad = process.env.SCRIPTS || './scripts/**/*.js'
+const logsDir = process.env.LOGS_DIR
 
 app.use(bodyParser.json({ verify: captureRaw }))
-app.use('/logs', authMiddleware, express.static(path.join(__dirname, 'logs')))
+
+if (logsDir) {
+  app.use('/logs', authMiddleware, express.static(logsDir))
+}
+
 // bunyanMiddleware gives us request id's and unique loggers per incoming request,
 // for satefy reasons we don't want to include the webhook GitHub secret in logs
 app.use(bunyanMiddleware({ logger, obscureHeaders: ['x-hub-signature'] }))

--- a/app.js
+++ b/app.js
@@ -15,7 +15,7 @@ const captureRaw = (req, res, buffer) => { req.raw = buffer }
 const app = express()
 
 const scriptsToLoad = process.env.SCRIPTS || './scripts/**/*.js'
-const logsDir = process.env.LOGS_DIR
+const logsDir = process.env.LOGS_DIR || ''
 
 app.use(bodyParser.json({ verify: captureRaw }))
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -7,20 +7,26 @@ const isRunningTests = process.env.npm_lifecycle_event === 'test'
 const stdoutLevel = isRunningTests ? 'FATAL' : 'INFO'
 
 const daysToKeepLogs = process.env.KEEP_LOGS || 10
+const logsDir = process.env.LOGS_DIR || ''
+const rotatingFilePath = path.join(logsDir, 'bot.log')
+
+let streams = [{
+  stream: process.stdout,
+  level: stdoutLevel
+}]
+
+// write to file when $LOGS_DIR is set
+if (logsDir) {
+  streams.push({
+    type: 'rotating-file',
+    path: rotatingFilePath,
+    period: '1d', // daily rotation
+    count: daysToKeepLogs,
+    level: 'debug'
+  })
+}
 
 module.exports = bunyan.createLogger({
   name: 'bot',
-  streams: [
-    {
-      stream: process.stdout,
-      level: stdoutLevel
-    },
-    {
-      type: 'rotating-file',
-      path: path.join(__dirname, '../logs/bot.log'),
-      period: '1d', // daily rotation
-      count: daysToKeepLogs,
-      level: 'debug'
-    }
-  ]
+  streams
 })

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
The main objective behind these changes are to not write logs into the project's `./logs` directory, cause that ends up being deleted whenever the bot is re-deployed. Having some days of historic logs are very valuable while debugging any issue.

Requires deployment changes: https://github.com/nodejs/build/pull/602