### PR TITLE
jenkins: allow citgm builds to push Jenkins build updates

### DIFF
--- a/scripts/jenkins-status.js
+++ b/scripts/jenkins-status.js
@@ -1,34 +1,45 @@
 'use strict'
 
 const pushJenkinsUpdate = require('../lib/push-jenkins-update')
+const enabledRepos = ['citgm', 'node']
 
 module.exports = function (app) {
-  app.post('/node/jenkins/start', (req, res) => {
+  app.post('/:repo/jenkins/start', (req, res) => {
     const isValid = pushJenkinsUpdate.validate(req.body)
+    const repo = req.params.repo
 
     if (!isValid) {
       return res.status(400).end('Invalid payload')
     }
 
+    if (!enabledRepos.includes(repo)) {
+      return res.status(400).end('Invalid repository')
+    }
+
     pushJenkinsUpdate.pushStarted({
       owner: 'nodejs',
-      repo: 'node',
+      repo,
       logger: req.log
     }, req.body)
 
     res.status(201).end()
   })
 
-  app.post('/node/jenkins/end', (req, res) => {
+  app.post('/:repo/jenkins/end', (req, res) => {
     const isValid = pushJenkinsUpdate.validate(req.body)
+    const repo = req.params.repo
 
     if (!isValid) {
       return res.status(400).end('Invalid payload')
     }
 
+    if (!enabledRepos.includes(repo)) {
+      return res.status(400).end('Invalid repository')
+    }
+
     pushJenkinsUpdate.pushEnded({
       owner: 'nodejs',
-      repo: 'node',
+      repo,
       logger: req.log
     }, req.body)
 

--- a/test/integration/push-jenkins-update.test.js
+++ b/test/integration/push-jenkins-update.test.js
@@ -12,7 +12,7 @@ const readFixture = require('../read-fixture')
 tap.test('Sends POST requests to https://api.github.com/repos/nodejs/node/statuses/<SHA>', (t) => {
   const jenkinsPayload = readFixture('success-payload.json')
 
-  const prCommitsScope = setupGetCommitsMock()
+  const prCommitsScope = setupGetCommitsMock('node')
   const scope = nock('https://api.github.com')
                   .filteringPath(ignoreQueryParams)
                   .post('/repos/nodejs/node/statuses/8a5fec2a6bade91e544a30314d7cf21f8a200de1')
@@ -30,10 +30,52 @@ tap.test('Sends POST requests to https://api.github.com/repos/nodejs/node/status
     })
 })
 
+tap.test('Allows repository name to be provided with URL parameter when pushing job started', (t) => {
+  const jenkinsPayload = readFixture('pending-payload.json')
+
+  const prCommitsScope = setupGetCommitsMock('citgm')
+  const scope = nock('https://api.github.com')
+                  .filteringPath(ignoreQueryParams)
+                  .post('/repos/nodejs/citgm/statuses/8a5fec2a6bade91e544a30314d7cf21f8a200de1')
+                  .reply(201)
+
+  t.plan(1)
+  t.tearDown(() => prCommitsScope.done() && scope.done())
+
+  supertest(app)
+    .post('/citgm/jenkins/start')
+    .send(jenkinsPayload)
+    .expect(201)
+    .end((err, res) => {
+      t.equal(err, null)
+    })
+})
+
+tap.test('Allows repository name to be provided with URL parameter when pushing job ended', (t) => {
+  const jenkinsPayload = readFixture('success-payload.json')
+
+  const prCommitsScope = setupGetCommitsMock('citgm')
+  const scope = nock('https://api.github.com')
+                  .filteringPath(ignoreQueryParams)
+                  .post('/repos/nodejs/citgm/statuses/8a5fec2a6bade91e544a30314d7cf21f8a200de1')
+                  .reply(201)
+
+  t.plan(1)
+  t.tearDown(() => prCommitsScope.done() && scope.done())
+
+  supertest(app)
+    .post('/citgm/jenkins/end')
+    .send(jenkinsPayload)
+    .expect(201)
+    .end((err, res) => {
+      t.equal(err, null)
+    })
+})
+
 tap.test('Forwards payload provided in incoming POST to GitHub status API', (t) => {
   const fixture = readFixture('success-payload.json')
 
-  const prCommitsScope = setupGetCommitsMock()
+  const prCommitsScope = setupGetCommitsMock('node')
   const scope = nock('https://api.github.com')
                   .filteringPath(ignoreQueryParams)
                   .post('/repos/nodejs/node/statuses/8a5fec2a6bade91e544a30314d7cf21f8a200de1', {
@@ -73,12 +115,29 @@ tap.test('Responds with 400 / "Bad request" when incoming request has invalid pa
     })
 })
 
-function setupGetCommitsMock () {
+tap.test('Responds with 400 / "Bad request" when incoming providing invalid repository name', (t) => {
+  const fixture = readFixture('pending-payload.json')
+
+  // don't care about the results, just want to prevent any HTTP request ever being made
+  nock('https://api.github.com')
+
+  t.plan(1)
+
+  supertest(app)
+    .post('/not-valid-repo-name/jenkins/start')
+    .send(fixture)
+    .expect(400, 'Invalid repository')
+    .end((err, res) => {
+      t.equal(err, null)
+    })
+})
+
+function setupGetCommitsMock (repoName) {
   const commitsResponse = readFixture('pr-commits.json')
 
   return nock('https://api.github.com')
             .filteringPath(ignoreQueryParams)
-            .get('/repos/nodejs/node/pulls/12345/commits')
+            .get(`/repos/nodejs/${repoName}/pulls/12345/commits`)
             .reply(200, commitsResponse)
 }
 


### PR DESCRIPTION
This changes allows [citgm](https://github.com/nodejs/citgm) builds to push updates like we already do for nodejs/node. That is done by making the Jenkins status update endpoints more generic, resolving the repository name from an URL parameter.

In practise this means the endpoints stay the same, but configurable:
- `/node/jenkins/start`
- `/citgm/jenkins/start`

Repository names are validated against a whitelist.

Refs https://github.com/nodejs/github-bot/issues/82#issuecomment-276715266

/cc @jbergstroem @gdams