### PR TITLE
labels: retry request for PR files if GitHub request fails

### DIFF
--- a/lib/node-repo.js
+++ b/lib/node-repo.js
@@ -1,10 +1,13 @@
 'use strict'
 
 const LRU = require('lru-cache')
+const retry = require('async').retry
 
 const githubClient = require('./github-client')
 const resolveLabels = require('./node-labels').resolveLabels
 const existingLabelsCache = new LRU({ max: 1, maxAge: 1000 * 60 * 60 })
+
+const fiveSeconds = 5 * 1000
 
 function deferredResolveLabelsThenUpdatePr (options) {
   const timeoutMillis = (options.timeoutInSec || 0) * 1000
@@ -14,11 +17,15 @@ function deferredResolveLabelsThenUpdatePr (options) {
 function resolveLabelsThenUpdatePr (options) {
   options.logger.debug('Fetching PR files for labelling')
 
-  githubClient.pullRequests.getFiles({
-    owner: options.owner,
-    repo: options.repo,
-    number: options.prId
-  }, (err, res) => {
+  const getFiles = (cb) => {
+    githubClient.pullRequests.getFiles({
+      owner: options.owner,
+      repo: options.repo,
+      number: options.prId
+    }, cb)
+  }
+
+  retry({ times: 5, interval: fiveSeconds }, getFiles, (err, res) => {
     if (err) {
       return options.logger.error(err, 'Error retrieving files from GitHub')
     }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "private": true,
   "license": "MIT",
   "dependencies": {
+    "async": "2.1.5",
     "basic-auth": "^1.0.4",
     "body-parser": "^1.15.0",
     "bunyan": "^1.8.1",


### PR DESCRIPTION
Trying to get around some intermittent GitHub API 404 failures, probably due to a race condition where the API hasn't yet got to update its PR cache or something similar.

Refs https://github.com/nodejs/github-bot/issues/88#issuecomment-288319518