### PR TITLE
labels: update labeling

### DIFF
--- a/lib/node-labels.js
+++ b/lib/node-labels.js
@@ -34,9 +34,8 @@ const subSystemLabelsMap = new Map([
   [/^src\/.+\.py$/, 'lib / src'],
 
   // properly label changes to v8 inspector integration-related files
-  [/^src\/inspector_/, ['c++', 'v8_inspector', 'dont-land-on-v4.x']],
-  [/^test\/(?:cctest|inspector)\//, ['test', 'v8_inspector',
-                                     'dont-land-on-v4.x']],
+  [/^src\/inspector_/, ['c++', 'inspector', 'dont-land-on-v4.x']],
+
   // don't want to label it a c++ update when we're "only" bumping the Node.js version
   [/^src\/(?!node_version\.h)/, 'c++'],
   // BUILDING.md should be marked as 'build' in addition to 'doc'
@@ -104,6 +103,10 @@ const exclusiveLabelsMap = new Map([
   [/^test\/doctool\//, ['test', 'doc', 'tools']],
   [/^test\/timers\//, ['test', 'timers']],
   [/^test\/pseudo-tty\//, ['test', 'tty']],
+  [/^test\/inspector\//, ['test', 'inspector', 'dont-land-on-v4.x']],
+  [/^test\/cctest\/test_inspector/, ['test', 'inspector', 'dont-land-on-v4.x']],
+  [/^test\/cctest\/test_url/, ['test', 'url-whatwg',
+                               'dont-land-on-v4.x', 'dont-land-on-v6.x']],
 
   [/^test\//, 'test'],
 

--- a/test/unit/node-labels.test.js
+++ b/test/unit/node-labels.test.js
@@ -163,12 +163,12 @@ tap.test('label: not "c++" when ./src/*.py has been changed', (t) => {
   t.end()
 })
 
-tap.test('label: "v8_inspector" when ./src/inspector_* has been changed', (t) => {
+tap.test('label: "inspector" when ./src/inspector_* has been changed', (t) => {
   const labels = nodeLabels.resolveLabels([
     'src/inspector_socket.cc'
   ])
 
-  t.same(labels, ['c++', 'v8_inspector', 'dont-land-on-v4.x'])
+  t.same(labels, ['c++', 'inspector', 'dont-land-on-v4.x'])
 
   t.end()
 })
@@ -469,8 +469,12 @@ const specificTests = [
   [ 'addons', ['addons/async-hello-world/binding.cc'] ],
   [ 'debugger', ['debugger/test-debugger-repl.js'] ],
   [ ['doc', 'tools'], ['doctool/test-doctool-html.js'] ],
+  [ ['inspector', 'dont-land-on-v4.x'],
+    ['inspector/test-inspector.js', 'cctest/test_inspector_socket.cc'] ],
   [ 'timers', ['timers/test-timers-reliability.js'] ],
-  [ 'tty', ['pseudo-tty/stdin-setrawmode.js'] ]
+  [ 'tty', ['pseudo-tty/stdin-setrawmode.js'] ],
+  [ ['url-whatwg', 'dont-land-on-v4.x', 'dont-land-on-v6.x'],
+    ['cctest/test_url.cc'] ]
 ]
 for (const info of specificTests) {
   let labels = info[0]


### PR DESCRIPTION
This updates the label used for inspector-related changes and makes test/cctest changes more accurate now that there are other, non-inspector tests in there.