### PR TITLE
labels: map dont-land-on-v4(6).x for napi

### DIFF
--- a/lib/node-labels.js
+++ b/lib/node-labels.js
@@ -29,7 +29,7 @@ const subSystemLabelsMap = new Map([
   [/^src\/.*win32.*/, ['c++', 'windows']],
   [/^src\/node_zlib/, ['c++', 'zlib']],
   [/^src\/tracing/, ['c++', 'tracing']],
-  [/^src\/node_api/, ['c++', 'n-api']],
+  [/^src\/node_api/, ['c++', 'n-api', 'dont-land-on-v4.x', 'dont-land-on-v6.x']],
 
   // don't label python files as c++
   [/^src\/.+\.py$/, 'lib / src'],
@@ -110,7 +110,7 @@ const exclusiveLabelsMap = new Map([
   [/^test\/cctest\/test_inspector/, ['test', 'inspector', 'dont-land-on-v4.x']],
   [/^test\/cctest\/test_url/, ['test', 'url-whatwg',
                                'dont-land-on-v4.x', 'dont-land-on-v6.x']],
-  [/^test\/addons-napi\//, ['test', 'n-api']],
+  [/^test\/addons-napi\//, ['test', 'n-api', 'dont-land-on-v4.x', 'dont-land-on-v6.x']],
   [/^test\/async-hooks\//, ['test', 'async_hooks']],
 
   [/^test\//, 'test'],
@@ -121,7 +121,7 @@ const exclusiveLabelsMap = new Map([
   [/^doc\/api\/(\w+)\.md$/, ['doc', '$1']],
   // n-api is treated separately since it is not a JS core module but is still
   // considered a subsystem of sorts
-  [/^doc\/api\/n-api.md$/, ['doc', 'n-api']],
+  [/^doc\/api\/n-api.md$/, ['doc', 'n-api', 'dont-land-on-v4.x', 'dont-land-on-v6.x']],
 
   [/^doc\//, 'doc'],
 


### PR DESCRIPTION
napi is not on v4 or v6