### PR TITLE
jenkins: paginate PR commits to find the latest commit

### DIFF
--- a/lib/push-jenkins-update.js
+++ b/lib/push-jenkins-update.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const url = require('url')
+
 const githubClient = require('./github-client')
 
 function pushStarted (options, build) {
@@ -59,14 +61,21 @@ function findPrInRef (gitRef) {
   return gitRef.split('/')[2]
 }
 
-function findLatestCommitInPr (options, cb) {
+function findLatestCommitInPr (options, cb, pageNumber = 1) {
   githubClient.pullRequests.getCommits({
     owner: options.owner,
     repo: options.repo,
-    number: options.pr
+    number: options.pr,
+    page: pageNumber,
+    per_page: 100
   }, (err, commitMetas) => {
     if (err) {
       return cb(err)
+    }
+
+    const lastPageURL = githubClient.hasLastPage(commitMetas)
+    if (lastPageURL) {
+      return findLatestCommitInPr(options, cb, pageNumberFromURL(lastPageURL))
     }
 
     const lastCommitMeta = commitMetas.pop()
@@ -101,6 +110,11 @@ function validate (payload) {
   return ['identifier', 'status', 'message', 'commit', 'url'].every(isString)
 }
 
+function pageNumberFromURL (githubUrl) {
+  return url.parse(githubUrl, true).query.page
+}
+
 exports.validate = validate
 exports.pushStarted = pushStarted
 exports.pushEnded = pushEnded
+exports.findLatestCommitInPr = findLatestCommitInPr

--- a/test/_fixtures/pull-requests-commits-page-1.json
+++ b/test/_fixtures/pull-requests-commits-page-1.json
@@ -1,0 +1,78 @@
+[
+    {
+        "sha": "45df0ee7171cf5f9642fb755be1b24075192347c",
+        "commit": {
+            "author": {
+                "name": "Jaideep Bajwa",
+                "email": "bjaideep@ca.ibm.com",
+                "date": "2016-11-01T06:53:37Z"
+            },
+            "committer": {
+                "name": "Myles Borins",
+                "email": "myles.borins@gmail.com",
+                "date": "2016-11-11T15:48:36Z"
+            },
+            "message": "v8: update make-v8.sh to use git\n\ngoogle build tool gclient doesn't support\nsvn anymore. Updating v8 build script to use\ngit instead.\n\nPR-URL: https://github.com/nodejs/node/pull/9393\nReviewed By: Sakthipriyan Vairamani <thechargingvolcano@gmail.com>\nReviewed-By: Ben Noordhuis <info@bnoordhuis.nl>\nReviewed-By: Michael Dawson <michael_dawson@ca.ibm.com>",
+            "tree": {
+                "sha": "42de90a38ab9499bad7d34a472584b164cc4640c",
+                "url": "https://api.github.com/repos/nodejs/node/git/trees/42de90a38ab9499bad7d34a472584b164cc4640c"
+            },
+            "url": "https://api.github.com/repos/nodejs/node/git/commits/45df0ee7171cf5f9642fb755be1b24075192347c",
+            "comment_count": 0,
+            "verification": {
+                "verified": false,
+                "reason": "unsigned",
+                "signature": null,
+                "payload": null
+            }
+        },
+        "url": "https://api.github.com/repos/nodejs/node/commits/45df0ee7171cf5f9642fb755be1b24075192347c",
+        "html_url": "https://github.com/nodejs/node/commit/45df0ee7171cf5f9642fb755be1b24075192347c",
+        "comments_url": "https://api.github.com/repos/nodejs/node/commits/45df0ee7171cf5f9642fb755be1b24075192347c/comments",
+        "author": {
+            "login": "jbajwa",
+            "id": 577562,
+            "avatar_url": "https://avatars1.githubusercontent.com/u/577562?v=4",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/jbajwa",
+            "html_url": "https://github.com/jbajwa",
+            "followers_url": "https://api.github.com/users/jbajwa/followers",
+            "following_url": "https://api.github.com/users/jbajwa/following{/other_user}",
+            "gists_url": "https://api.github.com/users/jbajwa/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/jbajwa/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/jbajwa/subscriptions",
+            "organizations_url": "https://api.github.com/users/jbajwa/orgs",
+            "repos_url": "https://api.github.com/users/jbajwa/repos",
+            "events_url": "https://api.github.com/users/jbajwa/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/jbajwa/received_events",
+            "type": "User",
+            "site_admin": false
+        },
+        "committer": {
+            "login": "MylesBorins",
+            "id": 498775,
+            "avatar_url": "https://avatars1.githubusercontent.com/u/498775?v=4",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/MylesBorins",
+            "html_url": "https://github.com/MylesBorins",
+            "followers_url": "https://api.github.com/users/MylesBorins/followers",
+            "following_url": "https://api.github.com/users/MylesBorins/following{/other_user}",
+            "gists_url": "https://api.github.com/users/MylesBorins/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/MylesBorins/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/MylesBorins/subscriptions",
+            "organizations_url": "https://api.github.com/users/MylesBorins/orgs",
+            "repos_url": "https://api.github.com/users/MylesBorins/repos",
+            "events_url": "https://api.github.com/users/MylesBorins/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/MylesBorins/received_events",
+            "type": "User",
+            "site_admin": false
+        },
+        "parents": [
+            {
+                "sha": "3daf11635dc8e0cf48110514000fd550ed79a425",
+                "url": "https://api.github.com/repos/nodejs/node/commits/3daf11635dc8e0cf48110514000fd550ed79a425",
+                "html_url": "https://github.com/nodejs/node/commit/3daf11635dc8e0cf48110514000fd550ed79a425"
+            }
+        ]
+    }
+]

--- a/test/_fixtures/pull-requests-commits-page-104.json
+++ b/test/_fixtures/pull-requests-commits-page-104.json
@@ -1,0 +1,78 @@
+[
+    {
+        "sha": "c1aa949064892dbe693750686c06f4ad5673e577",
+        "commit": {
+            "author": {
+                "name": "Jeremiah Senkpiel",
+                "email": "fishrock123@rocketmail.com",
+                "date": "2016-11-22T22:13:11Z"
+            },
+            "committer": {
+                "name": "Jeremiah Senkpiel",
+                "email": "fishrock123@rocketmail.com",
+                "date": "2016-11-22T22:13:11Z"
+            },
+            "message": "2016-11-22, Version 7.2.0 (Current)\n\nThis is a security release impacting Windows 10 users.\n\nNotable changes:\n\n* crypto: The `Decipher` methods `setAuthTag()` and `setAAD` now return\n`this`. (Kirill Fomichev) https://github.com/nodejs/node/pull/9398\n* dns: Implemented `{ttl: true}` for `resolve4()` and `resolve6()`.\n(Ben Noordhuis) https://github.com/nodejs/node/pull/9296 &\nhttps://github.com/nodejs/node/pull/9296\n* libuv: Upgrade to v1.10.1 (cjihrig)\nhttps://github.com/nodejs/node/pull/9647\n  - Fixed a potential buffer overflow when writing data to console on\nWindows 10. (CVE-2016-9551)\n* process: Added a new `external` property to the data returned by\n`memoryUsage()`. (Fedor Indutny)\nhttps://github.com/nodejs/node/pull/9587\n* tls: Fixed a memory leak when writes were queued on TLS connection\nthat was destroyed during handshake. (Fedor Indutny)\nhttps://github.com/nodejs/node/pull/9626\n* V8 (dep): Upgrade to v5.4.500.43 (Michaël Zasso)\nhttps://github.com/nodejs/node/pull/9697\n* v8: The data returned by `getHeapStatistics()` now includes three new\nfields: `malloced_memory`, `peak_malloced_memory`, and\n`does_zap_garbage`. (Gareth Ellis)\nhttps://github.com/nodejs/node/pull/8610\n\nPR-URL: https://github.com/nodejs/node/pull/9745",
+            "tree": {
+                "sha": "f87da6adf9e7e876103744caf4530793c3650129",
+                "url": "https://api.github.com/repos/nodejs/node/git/trees/f87da6adf9e7e876103744caf4530793c3650129"
+            },
+            "url": "https://api.github.com/repos/nodejs/node/git/commits/c1aa949064892dbe693750686c06f4ad5673e577",
+            "comment_count": 0,
+            "verification": {
+                "verified": false,
+                "reason": "unsigned",
+                "signature": null,
+                "payload": null
+            }
+        },
+        "url": "https://api.github.com/repos/nodejs/node/commits/c1aa949064892dbe693750686c06f4ad5673e577",
+        "html_url": "https://github.com/nodejs/node/commit/c1aa949064892dbe693750686c06f4ad5673e577",
+        "comments_url": "https://api.github.com/repos/nodejs/node/commits/c1aa949064892dbe693750686c06f4ad5673e577/comments",
+        "author": {
+            "login": "Fishrock123",
+            "id": 1093990,
+            "avatar_url": "https://avatars0.githubusercontent.com/u/1093990?v=4",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/Fishrock123",
+            "html_url": "https://github.com/Fishrock123",
+            "followers_url": "https://api.github.com/users/Fishrock123/followers",
+            "following_url": "https://api.github.com/users/Fishrock123/following{/other_user}",
+            "gists_url": "https://api.github.com/users/Fishrock123/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/Fishrock123/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/Fishrock123/subscriptions",
+            "organizations_url": "https://api.github.com/users/Fishrock123/orgs",
+            "repos_url": "https://api.github.com/users/Fishrock123/repos",
+            "events_url": "https://api.github.com/users/Fishrock123/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/Fishrock123/received_events",
+            "type": "User",
+            "site_admin": false
+        },
+        "committer": {
+            "login": "Fishrock123",
+            "id": 1093990,
+            "avatar_url": "https://avatars0.githubusercontent.com/u/1093990?v=4",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/Fishrock123",
+            "html_url": "https://github.com/Fishrock123",
+            "followers_url": "https://api.github.com/users/Fishrock123/followers",
+            "following_url": "https://api.github.com/users/Fishrock123/following{/other_user}",
+            "gists_url": "https://api.github.com/users/Fishrock123/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/Fishrock123/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/Fishrock123/subscriptions",
+            "organizations_url": "https://api.github.com/users/Fishrock123/orgs",
+            "repos_url": "https://api.github.com/users/Fishrock123/repos",
+            "events_url": "https://api.github.com/users/Fishrock123/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/Fishrock123/received_events",
+            "type": "User",
+            "site_admin": false
+        },
+        "parents": [
+            {
+                "sha": "02c2bf7d34141ddb903e215580ee79551790ac48",
+                "url": "https://api.github.com/repos/nodejs/node/commits/02c2bf7d34141ddb903e215580ee79551790ac48",
+                "html_url": "https://github.com/nodejs/node/commit/02c2bf7d34141ddb903e215580ee79551790ac48"
+            }
+        ]
+    }
+]

--- a/test/unit/push-jenkins-update.test.js
+++ b/test/unit/push-jenkins-update.test.js
@@ -1,0 +1,27 @@
+const tap = require('tap')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+const githubClient = require('../../lib/github-client')
+
+const readFixture = require('../read-fixture')
+
+tap.test('findLatestCommitInPr: paginates results when more than 100 commits in a PR', (t) => {
+  const commitsFixturePage1 = readFixture('pull-requests-commits-page-1.json')
+  const commitsFixturePage104 = readFixture('pull-requests-commits-page-104.json')
+
+  sinon.stub(githubClient.pullRequests, 'getCommits', (options, cb) => cb(null, options.page === 1 ? commitsFixturePage1 : commitsFixturePage104))
+  sinon.stub(githubClient, 'hasLastPage', (lastResult) => lastResult === commitsFixturePage1 ? 'https://api.github.com/repos/nodejs/node/pulls/9745/commits?page=104' : undefined)
+  const pushJenkinsUpdate = proxyquire('../../lib/push-jenkins-update', {'./github-client': githubClient})
+
+  t.plan(2)
+
+  pushJenkinsUpdate.findLatestCommitInPr({
+    owner: 'nodejs',
+    repo: 'node',
+    number: 9745
+  }, (err, commit) => {
+    t.equal(err, null)
+    t.equal(commit.sha, 'c1aa949064892dbe693750686c06f4ad5673e577')
+  })
+})


### PR DESCRIPTION
When pushing Jenkins status to a PR, we need to reference the commit SHA the inline GitHub PR status relates to.

These changes fixes a bug when handling enormous PRs with more than 100 commits (e.g. https://github.com/nodejs/node/pull/9745), where we have to paginate commits results for that PR to find the last commit SHA.

Fixes https://github.com/nodejs/github-bot/issues/97

/cc @nodejs/github-bot 