### PR TITLE
jenkins: add support for http-parser jenkins jobs

### DIFF
--- a/scripts/jenkins-status.js
+++ b/scripts/jenkins-status.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const pushJenkinsUpdate = require('../lib/push-jenkins-update')
-const enabledRepos = ['citgm', 'node']
+const enabledRepos = ['citgm', 'http-parser', 'node']
 
 const jenkinsIpWhitelist = process.env.JENKINS_WORKER_IPS ? process.env.JENKINS_WORKER_IPS.split(',') : []
 


### PR DESCRIPTION
Goes along with a PR in nodejs/build to add a http-parser Jenkins pipeline job.