### PR TITLE
jenkins: handle IPv4 remote address converted to IPv6

### DIFF
--- a/scripts/jenkins-status.js
+++ b/scripts/jenkins-status.js
@@ -6,7 +6,7 @@ const enabledRepos = ['citgm', 'http-parser', 'node']
 const jenkinsIpWhitelist = process.env.JENKINS_WORKER_IPS ? process.env.JENKINS_WORKER_IPS.split(',') : []
 
 function isJenkinsIpWhitelisted (req) {
-  const ip = req.connection.remoteAddress
+  const ip = req.connection.remoteAddress.split(':').pop()
 
   if (jenkinsIpWhitelist.length && !jenkinsIpWhitelist.includes(ip)) {
     req.log.warn({ ip }, 'Ignoring, not allowed to push Jenkins updates')


### PR DESCRIPTION
After the Jenkins IP whitelist was activated, the inline PR status reports for nodejs/node seems to be broken.

Seems like the issue here is that IPv4 remote addresses are converted to IPv6, which wasn't expected too happen.. Stripping any IPv6 parts off the remote addresses should make our IPv4 comparisons work as expected.

Refs https://github.com/nodejs/build/issues/1016
Refs https://github.com/nodejs/build/pull/985

/cc @maclover7 