### PR TITLE
chore: enable Travis CI for i18n repo

### DIFF
--- a/scripts/display-travis-status.js
+++ b/scripts/display-travis-status.js
@@ -20,7 +20,8 @@ const enabledRepos = {
   'llnode': { retry: 60, interval: 60 },
   'nan': { retry: 60, interval: 60 },
   'node-core-utils': { },
-  'core-validate-commit': { }
+  'core-validate-commit': { },
+  'i18n': { }
 }
 
 module.exports = function (app) {


### PR DESCRIPTION
Following steps outline by @rvagg in https://github.com/nodejs/build/issues/1221:

> It goes something like this:
> 
> 1. Add a webhook in your repo pointing to http://github-bot.nodejs.org:3333/hooks/github for pull requests and pushes, but you'll need the secret for that, I or @joyeecheung could do that or you could give @phillipj admin access to the repo and he could.
> 2. Get a PR into github-bot to add your repo to the list.
> 3. Profit .. ?

@phillipj I've added you as an admin on the i18n repo. If you're able to add the webhook, it would be much appreciated! Here's the URL: https://github.com/nodejs/i18n/settings/hooks/new

Resolves https://github.com/nodejs/build/issues/1221 and https://github.com/nodejs/i18n/issues/58