### PR TITLE
Stop logging all finished requests to reduce log noise

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,7 +25,11 @@ if (logsDir) {
 
 // bunyanMiddleware gives us request id's and unique loggers per incoming request,
 // for satefy reasons we don't want to include the webhook GitHub secret in logs
-app.use(bunyanMiddleware({ logger, obscureHeaders: ['x-hub-signature'] }))
+app.use(bunyanMiddleware({
+  logger,
+  level: 'trace',
+  obscureHeaders: ['x-hub-signature']
+}))
 
 require('./lib/github-events')(app)
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "basic-auth": "^1.0.4",
     "body-parser": "^1.15.0",
     "bunyan": "^1.8.1",
-    "bunyan-middleware": "^0.3.1",
+    "bunyan-middleware": "0.8.0",
     "debug": "^2.2.0",
     "dotenv": "^2.0.0",
     "express": "^4.13.4",


### PR DESCRIPTION
Thought I'd do a rounds of much needed cleanup on this bot, starting with the logs.

So far we have been logging absolutely *all* finished requests which results in a lot of noise in logs.

Local example:

```
$ npm start

..

12:13:32.529Z  INFO bot: Listening on port 3000
12:13:34.468Z  INFO bot: request finish (req_id=8812b800-6bde-11e8-add8-f393315a261f, duration=3.191551, req.query={}, req.remoteAddress=::1, req.remotePort=63894)
    GET /ping HTTP/1.1
    host: localhost:3000
    user-agent: curl/7.54.0
    accept: */*
    --
    HTTP/1.1 200 OK
    X-Powered-By: Express
    X-Request-Id: 8812b800-6bde-11e8-add8-f393315a261f
    Date: Sat, 09 Jun 2018 12:13:34 GMT
    Connection: keep-alive
    Content-Length: 4
```

Personally cannot remember once where this request information has actually been valuable. If it turns out I'm wrong, we could easily enable this again if needed for debugging purposes.

/cc @nodejs/github-bot 