### PR TITLE
Ignore Jenkins builds not related to pull requests

### DIFF
--- a/scripts/jenkins-status.js
+++ b/scripts/jenkins-status.js
@@ -16,6 +16,11 @@ function isJenkinsIpWhitelisted (req) {
   return true
 }
 
+function isRelatedToPullRequest (gitRef) {
+  // refs/pull/12345/head vs refs/heads/v8.x-staging/head
+  return gitRef.includes('/pull/')
+}
+
 module.exports = function (app) {
   app.post('/:repo/jenkins/start', (req, res) => {
     const isValid = pushJenkinsUpdate.validate(req.body)
@@ -23,6 +28,10 @@ module.exports = function (app) {
 
     if (!isValid) {
       return res.status(400).end('Invalid payload')
+    }
+
+    if (!isRelatedToPullRequest(req.body.ref)) {
+      return res.status(400).end('Will only push builds related to pull requests')
     }
 
     if (!enabledRepos.includes(repo)) {

--- a/test/_fixtures/jenkins-staging-failure-payload.json
+++ b/test/_fixtures/jenkins-staging-failure-payload.json
@@ -1,0 +1,8 @@
+{
+    "identifier": "node-test-commit-aix",
+    "status": "failure",
+    "message": "tests failed",
+    "commit": "084ef6016994a41ffbbe9e48584abe874a197d43",
+    "url": "https://ci.nodejs.org/job/node-test-commit-aix/15657/",
+    "ref": "refs/heads/v8.x-staging"
+}

--- a/test/integration/push-jenkins-update.test.js
+++ b/test/integration/push-jenkins-update.test.js
@@ -115,6 +115,23 @@ tap.test('Responds with 400 / "Bad request" when incoming request has invalid pa
     })
 })
 
+tap.test('Responds with 400 / "Bad request" when incoming request is not related to a pull request', (t) => {
+  const fixture = readFixture('jenkins-staging-failure-payload.json')
+
+  // don't care about the results, just want to prevent any HTTP request ever being made
+  nock('https://api.github.com')
+
+  t.plan(1)
+
+  supertest(app)
+    .post('/node/jenkins/start')
+    .send(fixture)
+    .expect(400, 'Will only push builds related to pull requests')
+    .end((err, res) => {
+      t.equal(err, null)
+    })
+})
+
 tap.test('Responds with 400 / "Bad request" when incoming providing invalid repository name', (t) => {
   const fixture = readFixture('pending-payload.json')
 


### PR DESCRIPTION
Another long standing cleanup to reduce the errors logs we've seen from the bot.

We have for a long time seen errors logged when Jenkins tells the bot to report inline pull requests statuses, when the build in question is not related to a pull request, but an ordinary branch like the `v8.x-staging` branch.

In short the error raised by github.com said we couldn't fetch commits related to pull request "v8.x-staging". It expects a pull request number to be provided when fetching those commits.

These changes checks if the git reference provided by Jenkins does in fact point to a pull request, if not the incoming request from Jenkins gets a `400 Bad Request` as response.

```
13:01:11.244 ERROR bot: Got error when retrieving GitHub commits for PR (req_id=78e986d9-6c52-485c-bac2-64c2797a7a40, pr=v8.x-staging, job=node-test-commit-aix, status=failure)
    err: {
      "code": "400",
      "status": "Bad Request",
      "message": "Invalid value for parameter 'number': v8.x-staging"
    }
```

/cc @nodejs/github-bot 