### PR TITLE
Log unhandled errors that occur upon startup or handling HTTP requests

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,4 +39,9 @@ glob.sync(scriptsToLoad).forEach((file) => {
   require(file)(app)
 })
 
+app.use(function logUnhandledErrors (err, req, res, next) {
+  logger.error(err, 'Unhandled error while responding to incoming HTTP request')
+  res.status(500).end()
+})
+
 module.exports = app

--- a/server.js
+++ b/server.js
@@ -39,3 +39,13 @@ if (process.env.SSE_RELAY) {
     }
   }
 }
+
+function logUnhandledException (err) {
+  logger.fatal(err, 'Unchaught exception, terminating bot process immediately')
+
+  // leave time for error to be written to disk before exiting process
+  setTimeout(() => process.exit(1), 10)
+}
+
+process.on('uncaughtException', logUnhandledException)
+process.on('unhandledRejection', logUnhandledException)


### PR DESCRIPTION
Whenever unhandled errors are raised, it's especially important for us to get some hints of what happened. In a perfect world these kinds of errors shouldn't happen, but ofcourse they do for time to time..

The last time we had this kinds of error, there were no errors visible in the logs, other than seeing that the bot process seemed to restart more than usual.

While working in these changes, I found that the default unhandled error handler in express.js, writes the error to stdout, not into the log log files we've write through via bunyan.

With these changes in place we'll get something like this in the logs:

```
19:16:26.303Z FATAL bot: Unchaught exception, terminating bot process immediately
    ReferenceError: invokingNoneExistentFunction is not defined
        at Promise.resolve.then (/github-bot/app.js:47:31)
        at process._tickCallback (internal/process/next_tick.js:109:7)
        at Module.runMain (module.js:613:11)
        at run (bootstrap_node.js:387:7)
        at startup (bootstrap_node.js:153:9)
        at bootstrap_node.js:500:3
```

Refs https://github.com/nodejs/github-bot/pull/174

/cc @nodejs/github-bot 