### PR TITLE
Jenkins: ignore ended builds not related to pull requests

### DIFF
--- a/scripts/jenkins-status.js
+++ b/scripts/jenkins-status.js
@@ -59,6 +59,10 @@ module.exports = function (app) {
       return res.status(400).end('Invalid payload')
     }
 
+    if (!isRelatedToPullRequest(req.body.ref)) {
+      return res.status(400).end('Will only push builds related to pull requests')
+    }
+
     if (!enabledRepos.includes(repo)) {
       return res.status(400).end('Invalid repository')
     }

--- a/test/integration/push-jenkins-update.test.js
+++ b/test/integration/push-jenkins-update.test.js
@@ -115,7 +115,7 @@ tap.test('Responds with 400 / "Bad request" when incoming request has invalid pa
     })
 })
 
-tap.test('Responds with 400 / "Bad request" when incoming request is not related to a pull request', (t) => {
+tap.test('Responds with 400 / "Bad request" when build started status update is not related to a pull request', (t) => {
   const fixture = readFixture('jenkins-staging-failure-payload.json')
 
   // don't care about the results, just want to prevent any HTTP request ever being made
@@ -125,6 +125,23 @@ tap.test('Responds with 400 / "Bad request" when incoming request is not related
 
   supertest(app)
     .post('/node/jenkins/start')
+    .send(fixture)
+    .expect(400, 'Will only push builds related to pull requests')
+    .end((err, res) => {
+      t.equal(err, null)
+    })
+})
+
+tap.test('Responds with 400 / "Bad request" when build ended status update is not related to a pull request', (t) => {
+  const fixture = readFixture('jenkins-staging-failure-payload.json')
+
+  // don't care about the results, just want to prevent any HTTP request ever being made
+  nock('https://api.github.com')
+
+  t.plan(1)
+
+  supertest(app)
+    .post('/node/jenkins/end')
     .send(fixture)
     .expect(400, 'Will only push builds related to pull requests')
     .end((err, res) => {


### PR DESCRIPTION
This is an improvement of a recent attemt to ignore any Jenkins build status updates that was *not* related to pull requests.

While looking at the logs after the last fix was merged, it surprised me that we still got those kinds of errors popping up:

```
22:24:02.994 ERROR bot: Got error when retrieving GitHub commits for PR (req_id=3741a210-6cec-11e8-a3a3-e194f9df710c, pr=master, job=node-test-commit-plinux, status=success)
    err: {
      "code": "400",
      "status": "Bad Request",
      "message": "Invalid value for parameter 'number': master"
    }
```

Looking closely on the info included in that error log, made it clear it could be an issue on builds that had *ended*. Digging into the fix that was recently pushed, I discovered that fix only applied to for statuses Jenkins pushes to the bot when it *starts* builds.

Applying the previous fix to the bot endpoint that handles *ended* Jenkins builds as well, should make these error logs disappear.

Refs https://github.com/nodejs/github-bot/pull/177

/cc @nodejs/github-bot 