### PR TITLE
chore: don't apply dont-land labels for 6.x napi and url

### DIFF
--- a/lib/node-labels.js
+++ b/lib/node-labels.js
@@ -21,15 +21,14 @@ const subSystemLabelsMap = new Map([
   [/^src\/timer_/, ['c++', 'timers']],
   [/^src\/(?:CNNICHashWhitelist|node_root_certs|tls_)/, ['c++', 'tls']],
   [/^src\/tty_/, ['c++', 'tty']],
-  [/^src\/node_url/, ['c++', 'url-whatwg',
-                      'dont-land-on-v4.x', 'dont-land-on-v6.x']],
+  [/^src\/node_url/, ['c++', 'url-whatwg', 'dont-land-on-v4.x']],
   [/^src\/node_util/, ['c++', 'util']],
   [/^src\/(?:node_v8|v8abbr)/, ['c++', 'V8 Engine']],
   [/^src\/node_contextify/, ['c++', 'vm']],
   [/^src\/.*win32.*/, ['c++', 'windows']],
   [/^src\/node_zlib/, ['c++', 'zlib']],
   [/^src\/tracing/, ['c++', 'tracing']],
-  [/^src\/node_api/, ['c++', 'n-api', 'dont-land-on-v4.x', 'dont-land-on-v6.x']],
+  [/^src\/node_api/, ['c++', 'n-api', 'dont-land-on-v4.x']],
   [/^src\/node_http2/, ['c++', 'http2', 'dont-land-on-v4.x', 'dont-land-on-v6.x']],
 
   // don't label python files as c++
@@ -88,8 +87,7 @@ const subSystemLabelsMap = new Map([
   [/^lib\/\w+\/socket_list/, 'net'],
   [/^lib\/\w+\/streams$/, 'stream'],
   [/^lib\/.*http2/, ['http2', 'dont-land-on-v4.x', 'dont-land-on-v6.x']],
-  [/^lib\/internal\/url\.js$/, ['url-whatwg',
-                                'dont-land-on-v4.x', 'dont-land-on-v6.x']],
+  [/^lib\/internal\/url\.js$/, ['url-whatwg', 'dont-land-on-v4.x']],
   // All other lib/ files map directly
   [/^lib\/_(\w+)_\w+\.js?$/, '$1'], // e.g. _(stream)_wrap
   [/^lib(\/internal)?\/(\w+)\.js?$/, '$2'], // other .js files
@@ -113,9 +111,8 @@ const exclusiveLabelsMap = new Map([
   [/^test\/pseudo-tty\//, ['test', 'tty']],
   [/^test\/inspector\//, ['test', 'inspector', 'dont-land-on-v4.x']],
   [/^test\/cctest\/test_inspector/, ['test', 'inspector', 'dont-land-on-v4.x']],
-  [/^test\/cctest\/test_url/, ['test', 'url-whatwg',
-                               'dont-land-on-v4.x', 'dont-land-on-v6.x']],
-  [/^test\/addons-napi\//, ['test', 'n-api', 'dont-land-on-v4.x', 'dont-land-on-v6.x']],
+  [/^test\/cctest\/test_url/, ['test', 'url-whatwg', 'dont-land-on-v4.x']],
+  [/^test\/addons-napi\//, ['test', 'n-api', 'dont-land-on-v4.x']],
   [/^test\/async-hooks\//, ['test', 'async_hooks']],
 
   [/^test\//, 'test'],
@@ -124,7 +121,7 @@ const exclusiveLabelsMap = new Map([
   [/^doc\/api\/modules.md$/, ['doc', 'module']],
   // n-api is treated separately since it is not a JS core module but is still
   // considered a subsystem of sorts
-  [/^doc\/api\/n-api.md$/, ['doc', 'n-api', 'dont-land-on-v4.x', 'dont-land-on-v6.x']],
+  [/^doc\/api\/n-api.md$/, ['doc', 'n-api', 'dont-land-on-v4.x']],
   // automatically tag JS subsystem-specific API doc changes
   [/^doc\/api\/(\w+)\.md$/, ['doc', '$1']],
 

--- a/test/unit/node-labels.test.js
+++ b/test/unit/node-labels.test.js
@@ -110,7 +110,7 @@ const srcCases = [
      'tls_wrap.cc',
      'tls_wrap.h'] ],
   [ 'tty', ['tty_wrap.cc', 'tty_wrap.h'] ],
-  [ ['url-whatwg', 'dont-land-on-v4.x', 'dont-land-on-v6.x'],
+  [ ['url-whatwg', 'dont-land-on-v4.x'],
     ['node_url.cc', 'node_url.h'] ],
   [ 'util', ['node_util.cc'] ],
   [ 'V8 Engine', ['node_v8.cc', 'v8abbr.h'] ],
@@ -424,7 +424,7 @@ tap.test('label: dont-land-on labels for WHATWG URL', (t) => {
     'lib/internal/url.js'
   ])
 
-  t.same(labels, ['url-whatwg', 'dont-land-on-v4.x', 'dont-land-on-v6.x'])
+  t.same(labels, ['url-whatwg', 'dont-land-on-v4.x'])
 
   t.end()
 })
@@ -506,7 +506,7 @@ const specificTests = [
     ['inspector/test-inspector.js', 'cctest/test_inspector_socket.cc'] ],
   [ 'timers', ['timers/test-timers-reliability.js'] ],
   [ 'tty', ['pseudo-tty/stdin-setrawmode.js'] ],
-  [ ['url-whatwg', 'dont-land-on-v4.x', 'dont-land-on-v6.x'],
+  [ ['url-whatwg', 'dont-land-on-v4.x'],
     ['cctest/test_url.cc'] ]
 ]
 for (const info of specificTests) {
@@ -567,11 +567,11 @@ for (const info of specificTools) {
 [
   [ ['V8 Engine', 'post-mortem'],
     ['deps/v8/tools/gen-postmortem-metadata.py'] ],
-  [ ['c++', 'n-api', 'dont-land-on-v4.x', 'dont-land-on-v6.x'],
+  [ ['c++', 'n-api', 'dont-land-on-v4.x'],
     ['src/node_api.cc', 'src/node_api.h', 'src/node_api_types.h'] ],
-  [ ['test', 'n-api', 'dont-land-on-v4.x', 'dont-land-on-v6.x'],
+  [ ['test', 'n-api', 'dont-land-on-v4.x'],
     ['test/addons-napi/foo'] ],
-  [ ['doc', 'n-api', 'dont-land-on-v4.x', 'dont-land-on-v6.x'],
+  [ ['doc', 'n-api', 'dont-land-on-v4.x'],
     ['doc/api/n-api.md'] ]
 ].forEach((info) => {
   const labels = info[0]


### PR DESCRIPTION
These apis were backported to v6.x