### PR TITLE
Bump request to production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "express": "^4.13.4",
     "github": "^7.0.1",
     "glob": "^7.0.3",
-    "lru-cache": "^4.0.1"
+    "lru-cache": "^4.0.1",
+    "request": "^2.72.0"
   },
   "devDependencies": {
     "eventsource": "^0.2.1",
@@ -31,7 +32,6 @@
     "nock": "^8.0.0",
     "nodemon": "^1.9.1",
     "proxyquire": "^1.7.10",
-    "request": "^2.72.0",
     "sinon": "^1.17.6",
     "standard": "^6.0.7",
     "supertest": "^1.2.0",


### PR DESCRIPTION
```
[...]
Jun 22 16:14:39 infra-rackspace-debian8-x64-1 systemd[1]: Starting github-bot...
Jun 22 16:14:39 infra-rackspace-debian8-x64-1 systemd[1]: Started github-bot.
Jun 22 16:14:39 infra-rackspace-debian8-x64-1 node[28941]: {"name":"bot","hostname":"infra-rackspace-debian8-x64-1","pid":28941,"level":30,"msg":"Loading: ./scripts/attempt-backport.js","time":"2018-06-22T16:14:39.884Z","v":0}
Jun 22 16:14:39 infra-rackspace-debian8-x64-1 node[28941]: module.js:478
Jun 22 16:14:39 infra-rackspace-debian8-x64-1 node[28941]: throw err;
Jun 22 16:14:39 infra-rackspace-debian8-x64-1 node[28941]: ^
Jun 22 16:14:39 infra-rackspace-debian8-x64-1 node[28941]: Error: Cannot find module 'request'
[...]
```