### PR TITLE
remove dont-land-on-v4.x

### DIFF
--- a/lib/node-labels.js
+++ b/lib/node-labels.js
@@ -21,21 +21,21 @@ const subSystemLabelsMap = new Map([
   [/^src\/timer_/, ['c++', 'timers']],
   [/^src\/(?:CNNICHashWhitelist|node_root_certs|tls_)/, ['c++', 'tls']],
   [/^src\/tty_/, ['c++', 'tty']],
-  [/^src\/node_url/, ['c++', 'url-whatwg', 'dont-land-on-v4.x']],
+  [/^src\/node_url/, ['c++', 'url-whatwg']],
   [/^src\/node_util/, ['c++', 'util']],
   [/^src\/(?:node_v8|v8abbr)/, ['c++', 'V8 Engine']],
   [/^src\/node_contextify/, ['c++', 'vm']],
   [/^src\/.*win32.*/, ['c++', 'windows']],
   [/^src\/node_zlib/, ['c++', 'zlib']],
   [/^src\/tracing/, ['c++', 'tracing']],
-  [/^src\/node_api/, ['c++', 'n-api', 'dont-land-on-v4.x']],
-  [/^src\/node_http2/, ['c++', 'http2', 'dont-land-on-v4.x', 'dont-land-on-v6.x']],
+  [/^src\/node_api/, ['c++', 'n-api']],
+  [/^src\/node_http2/, ['c++', 'http2', 'dont-land-on-v6.x']],
 
   // don't label python files as c++
   [/^src\/.+\.py$/, 'lib / src'],
 
   // properly label changes to v8 inspector integration-related files
-  [/^src\/inspector_/, ['c++', 'inspector', 'dont-land-on-v4.x']],
+  [/^src\/inspector_/, ['c++', 'inspector']],
 
   // don't want to label it a c++ update when we're "only" bumping the Node.js version
   [/^src\/(?!node_version\.h)/, 'c++'],
@@ -72,8 +72,8 @@ const subSystemLabelsMap = new Map([
   [/^deps\/uv\//, 'libuv'],
   [/^deps\/v8\/tools\/gen-postmortem-metadata\.py/, ['V8 Engine', 'post-mortem']],
   [/^deps\/v8\//, 'V8 Engine'],
-  [/^deps\/nghttp2\/nghttp2\.gyp/, ['build', 'http2', 'dont-land-on-v4.x', 'dont-land-on-v6.x']],
-  [/^deps\/nghttp2\//, ['http2', 'dont-land-on-v4.x', 'dont-land-on-v6.x']],
+  [/^deps\/nghttp2\/nghttp2\.gyp/, ['build', 'http2', 'dont-land-on-v6.x']],
+  [/^deps\/nghttp2\//, ['http2', 'dont-land-on-v6.x']],
   [/^deps\/([^/]+)/, '$1'],
 
   /* JS subsystems */
@@ -86,8 +86,8 @@ const subSystemLabelsMap = new Map([
   [/^lib\/\w+\/v8_prof_/, 'tools'],
   [/^lib\/\w+\/socket_list/, 'net'],
   [/^lib\/\w+\/streams$/, 'stream'],
-  [/^lib\/.*http2/, ['http2', 'dont-land-on-v4.x', 'dont-land-on-v6.x']],
-  [/^lib\/internal\/url\.js$/, ['url-whatwg', 'dont-land-on-v4.x']],
+  [/^lib\/.*http2/, ['http2', 'dont-land-on-v6.x']],
+  [/^lib\/internal\/url\.js$/, ['url-whatwg']],
   // All other lib/ files map directly
   [/^lib\/_(\w+)_\w+\.js?$/, '$1'], // e.g. _(stream)_wrap
   [/^lib(\/internal)?\/(\w+)\.js?$/, '$2'], // other .js files
@@ -109,10 +109,10 @@ const exclusiveLabelsMap = new Map([
   [/^test\/doctool\//, ['test', 'doc', 'tools']],
   [/^test\/timers\//, ['test', 'timers']],
   [/^test\/pseudo-tty\//, ['test', 'tty']],
-  [/^test\/inspector\//, ['test', 'inspector', 'dont-land-on-v4.x']],
-  [/^test\/cctest\/test_inspector/, ['test', 'inspector', 'dont-land-on-v4.x']],
-  [/^test\/cctest\/test_url/, ['test', 'url-whatwg', 'dont-land-on-v4.x']],
-  [/^test\/addons-napi\//, ['test', 'n-api', 'dont-land-on-v4.x']],
+  [/^test\/inspector\//, ['test', 'inspector']],
+  [/^test\/cctest\/test_inspector/, ['test', 'inspector']],
+  [/^test\/cctest\/test_url/, ['test', 'url-whatwg']],
+  [/^test\/addons-napi\//, ['test', 'n-api']],
   [/^test\/async-hooks\//, ['test', 'async_hooks']],
 
   [/^test\//, 'test'],
@@ -121,7 +121,7 @@ const exclusiveLabelsMap = new Map([
   [/^doc\/api\/modules.md$/, ['doc', 'module']],
   // n-api is treated separately since it is not a JS core module but is still
   // considered a subsystem of sorts
-  [/^doc\/api\/n-api.md$/, ['doc', 'n-api', 'dont-land-on-v4.x']],
+  [/^doc\/api\/n-api.md$/, ['doc', 'n-api']],
   // automatically tag JS subsystem-specific API doc changes
   [/^doc\/api\/(\w+)\.md$/, ['doc', '$1']],
 

--- a/test/unit/node-labels.test.js
+++ b/test/unit/node-labels.test.js
@@ -110,7 +110,7 @@ const srcCases = [
      'tls_wrap.cc',
      'tls_wrap.h'] ],
   [ 'tty', ['tty_wrap.cc', 'tty_wrap.h'] ],
-  [ ['url-whatwg', 'dont-land-on-v4.x'],
+  [ ['url-whatwg'],
     ['node_url.cc', 'node_url.h'] ],
   [ 'util', ['node_util.cc'] ],
   [ 'V8 Engine', ['node_v8.cc', 'v8abbr.h'] ],
@@ -168,7 +168,7 @@ tap.test('label: "inspector" when ./src/inspector_* has been changed', (t) => {
     'src/inspector_socket.cc'
   ])
 
-  t.same(labels, ['c++', 'inspector', 'dont-land-on-v4.x'])
+  t.same(labels, ['c++', 'inspector'])
 
   t.end()
 })
@@ -419,16 +419,6 @@ tap.test('label: build label (windows)', (t) => {
   t.end()
 })
 
-tap.test('label: dont-land-on labels for WHATWG URL', (t) => {
-  const labels = nodeLabels.resolveLabels([
-    'lib/internal/url.js'
-  ])
-
-  t.same(labels, ['url-whatwg', 'dont-land-on-v4.x'])
-
-  t.end()
-})
-
 tap.test('label: doc label for non-subsystem API doc changes', (t) => {
   const labels = nodeLabels.resolveLabels([
     'doc/api/_toc.md',
@@ -502,11 +492,11 @@ const specificTests = [
   [ 'addons', ['addons/async-hello-world/binding.cc'] ],
   [ 'debugger', ['debugger/test-debugger-repl.js'] ],
   [ ['doc', 'tools'], ['doctool/test-doctool-html.js'] ],
-  [ ['inspector', 'dont-land-on-v4.x'],
+  [ ['inspector'],
     ['inspector/test-inspector.js', 'cctest/test_inspector_socket.cc'] ],
   [ 'timers', ['timers/test-timers-reliability.js'] ],
   [ 'tty', ['pseudo-tty/stdin-setrawmode.js'] ],
-  [ ['url-whatwg', 'dont-land-on-v4.x'],
+  [ ['url-whatwg'],
     ['cctest/test_url.cc'] ]
 ]
 for (const info of specificTests) {
@@ -567,11 +557,11 @@ for (const info of specificTools) {
 [
   [ ['V8 Engine', 'post-mortem'],
     ['deps/v8/tools/gen-postmortem-metadata.py'] ],
-  [ ['c++', 'n-api', 'dont-land-on-v4.x'],
+  [ ['c++', 'n-api'],
     ['src/node_api.cc', 'src/node_api.h', 'src/node_api_types.h'] ],
-  [ ['test', 'n-api', 'dont-land-on-v4.x'],
+  [ ['test', 'n-api'],
     ['test/addons-napi/foo'] ],
-  [ ['doc', 'n-api', 'dont-land-on-v4.x'],
+  [ ['doc', 'n-api'],
     ['doc/api/n-api.md'] ]
 ].forEach((info) => {
   const labels = info[0]
@@ -615,16 +605,16 @@ tap.test('label: "build" when ./android-configure has been changed', (t) => {
 });
 
 [
-  [ ['http2', 'dont-land-on-v4.x', 'dont-land-on-v6.x'],
+  [ ['http2', 'dont-land-on-v6.x'],
     ['lib/http2.js',
      'lib/internal/http2/core.js',
      'deps/nghttp2/lib/nghttp2_buf.c'] ],
-  [ ['c++', 'http2', 'dont-land-on-v4.x', 'dont-land-on-v6.x'],
+  [ ['c++', 'http2', 'dont-land-on-v6.x'],
     ['src/node_http2.cc',
      'src/node_http2.h',
      'src/node_http2_core.h',
      'src/node_http2_core-inl.h'] ],
-  [ ['build', 'http2', 'dont-land-on-v4.x', 'dont-land-on-v6.x'],
+  [ ['build', 'http2', 'dont-land-on-v6.x'],
     ['deps/nghttp2/nghttp2.gyp'] ],
   [ ['doc', 'http2'], ['doc/api/http2.md'] ]
 ].forEach((info) => {


### PR DESCRIPTION
Nothing will ever land on 4.x ever again, so there's no need for the
dont-land-on-v4.x label. After this PR lands, hopefully it can be
removed from the GitHub interface.