### PR TITLE
node-repo: fix getBotPrLabels

### DIFF
--- a/lib/node-repo.js
+++ b/lib/node-repo.js
@@ -153,11 +153,12 @@ function getBotPrLabels (options, cb) {
     page: 1,
     per_page: 100, // we probably won't hit this
     issue_number: options.prId
-  }, (err, events) => {
+  }, (err, res) => {
     if (err) {
       return cb(err)
     }
 
+    const events = res.data || []
     const ourLabels = []
 
     for (const event of events) {

--- a/test/_fixtures/pull-request-events-2.json
+++ b/test/_fixtures/pull-request-events-2.json
@@ -1,0 +1,22 @@
+{
+  "data": [
+    {
+      "event": "labeled",
+      "actor": {
+        "login": "nodejs-github-bot"
+      },
+      "label": {
+        "name": "testlabel"
+      }
+    },
+    {
+      "event": "unlabeled",
+      "actor": {
+        "login": "nodejs-github-bot"
+      },
+      "label": {
+        "name": "testlabel"
+      }
+    }
+  ]
+}

--- a/test/_fixtures/pull-request-events.json
+++ b/test/_fixtures/pull-request-events.json
@@ -1,0 +1,13 @@
+{
+  "data": [
+    {
+      "event": "labeled",
+      "actor": {
+        "login": "nodejs-github-bot"
+      },
+      "label": {
+        "name": "testlabel"
+      }
+    }
+  ]
+}

--- a/test/unit/node-repo.test.js
+++ b/test/unit/node-repo.test.js
@@ -92,3 +92,33 @@ tap.test('fetchExistingLabels(): can retrieve more than 100 labels', (t) => {
     t.ok(existingLabels.includes('windows'))
   })
 })
+
+tap.test('getBotPrLabels(): returns labels added by nodejs-github-bot', (t) => {
+  const events = readFixture('pull-request-events.json')
+  sinon.stub(githubClient.issues, 'getEvents', (options, cb) => { cb(null, events) })
+  const nodeRepo = proxyquire('../../lib/node-repo', {'./github-client': githubClient})
+
+  t.plan(1)
+  t.tearDown(() => {
+    githubClient.issues.getEvents.restore()
+  })
+
+  nodeRepo.getBotPrLabels({ owner: 'nodejs', repo: 'node', prId: '1' }, (_, labels) => {
+    t.same(labels, ['testlabel'])
+  })
+})
+
+tap.test('getBotPrLabels(): returns net labels added/removed by nodejs-github-bot', (t) => {
+  const events = readFixture('pull-request-events-2.json')
+  sinon.stub(githubClient.issues, 'getEvents', (options, cb) => { cb(null, events) })
+  const nodeRepo = proxyquire('../../lib/node-repo', {'./github-client': githubClient})
+
+  t.plan(1)
+  t.tearDown(() => {
+    githubClient.issues.getEvents.restore()
+  })
+
+  nodeRepo.getBotPrLabels({ owner: 'nodejs', repo: 'node', prId: '1' }, (_, labels) => {
+    t.same(labels, [])
+  })
+})


### PR DESCRIPTION
Fixes the following error occurring in production, likely happening due
to the recent bump in dependencies.

```
10:49:01.780 FATAL bot: Unchaught exception, terminating bot process immediately
    TypeError: events[Symbol.iterator] is not a function
        at githubClient.issues.getEvents (/home/iojs/github-bot/lib/node-repo.js:163:23)
        at /home/iojs/github-bot/node_modules/github/lib/index.js:912:9
        at callCallback (/home/iojs/github-bot/node_modules/github/lib/index.js:738:9)
        at IncomingMessage.<anonymous> (/home/iojs/github-bot/node_modules/github/lib/index.js:810:13)
        at emitNone (events.js:91:20)
        at IncomingMessage.emit (events.js:185:7)
        at endReadableNT (_stream_readable.js:978:12)
        at _combinedTickCallback (internal/process/next_tick.js:80:11)
        at process._tickCallback (internal/process/next_tick.js:104:9)
```

Refs: https://github.com/nodejs/github-bot/pull/188