### PR TITLE
node-repo: switch option name

### DIFF
--- a/lib/node-repo.js
+++ b/lib/node-repo.js
@@ -65,7 +65,7 @@ function updatePrWithLabels (options, labels) {
     owner: options.owner,
     repo: options.repo,
     number: options.prId,
-    body: labels
+    labels: labels
   }, (err) => {
     if (err) {
       return options.logger.error(err, 'Error while adding labels')


### PR DESCRIPTION
In an attempt to fix the following error on the production server:

```
11:40:52.491 DEBUG bot: Resolved labels: doc,vm (req_id=47558d90-8c33-11e8-8f2d-6778d538d753, pr=nodejs/node/#21911, action=pull_request.opened)
11:40:52.492 DEBUG bot: Trying to add labels: doc,vm (req_id=47558d90-8c33-11e8-8f2d-6778d538d753, pr=nodejs/node/#21911, action=pull_request.opened)
11:40:52.492 ERROR bot: Error while adding labels (req_id=47558d90-8c33-11e8-8f2d-6778d538d753, pr=nodejs/node/#21911, action=pull_request.opened)
    err: {
      "code": "400",
      "status": "Bad Request",
      "message": "Empty value for parameter 'labels': undefined"
    }
```

Refs: https://github.com/nodejs/github-bot/issues/192#issuecomment-406734218