### PR TITLE
remove redundant indent_style from editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,5 +16,4 @@ indent_size = 2
 trim_trailing_whitespace = false
 
 [package.json]
-indent_style = space
 indent_size = 2


### PR DESCRIPTION
`indent_style` is applied to all the files based on `[*]` entry. We
don't have to specify the same for `package.json` explicitly.