### PR TITLE
Fix comment typo

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,7 +24,7 @@ if (logsDir) {
 }
 
 // bunyanMiddleware gives us request id's and unique loggers per incoming request,
-// for satefy reasons we don't want to include the webhook GitHub secret in logs
+// for safety reasons we don't want to include the webhook GitHub secret in logs
 app.use(bunyanMiddleware({
   logger,
   level: 'trace',


### PR DESCRIPTION
- Fix typing mistake: `satefy` --> `safety`.