### PR TITLE
Bump Node.js version from 6 to 8 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 sudo: false
 language: node_js
 node_js:
-  - 6
+  - 8


### PR DESCRIPTION
As a precursor to upgrading the Node.js version we run on the github-bot server, this updates the version used by Travis CI when running our tests.

/cc @nodejs/github-bot 