### PR TITLE
scripts: fix reading credentials for jenkins

### DIFF
--- a/scripts/trigger-jenkins-build.js
+++ b/scripts/trigger-jenkins-build.js
@@ -52,7 +52,7 @@ function buildParametersForRepo (options, repo) {
 
 function triggerBuild (options, cb) {
   const { repo } = options
-  const base64Credentials = Buffer.from(jenkinsApiCredentials, 'base64')
+  const base64Credentials = Buffer.from(jenkinsApiCredentials).toString('base64')
   const authorization = `Basic ${base64Credentials}`
 
   const jobName = getJobNameForRepo(repo)


### PR DESCRIPTION
The existing code assumes that the credentials are already in base64,
but they are actually not. The code has to read the credentials in plain
text and base 64 encode them.

Ref: https://github.com/nodejs/github-bot/pull/206#discussion_r236054041

---

@maclover7 @phillipj 