### PR TITLE
labels: add "report" label

### DIFF
--- a/lib/node-labels.js
+++ b/lib/node-labels.js
@@ -30,6 +30,7 @@ const subSystemLabelsMap = new Map([
   [/^src\/tracing/, ['c++', 'tracing']],
   [/^src\/node_api/, ['c++', 'n-api']],
   [/^src\/node_http2/, ['c++', 'http2', 'dont-land-on-v6.x']],
+  [/^src\/node_report/, ['c++', 'report']],
 
   // don't label python files as c++
   [/^src\/.+\.py$/, 'lib / src'],
@@ -98,8 +99,8 @@ const jsSubsystemList = [
   'debugger', 'assert', 'async_hooks', 'buffer', 'child_process', 'cluster',
   'console', 'crypto', 'dgram', 'dns', 'domain', 'events', 'fs', 'http',
   'https', 'http2', 'module', 'net', 'os', 'path', 'process', 'querystring',
-  'readline', 'repl', 'stream', 'string_decoder', 'timers', 'tls', 'tty', 'url',
-  'util', 'v8', 'vm', 'zlib'
+  'readline', 'repl', 'report', 'stream', 'string_decoder', 'timers', 'tls',
+  'tty', 'url', 'util', 'v8', 'vm', 'zlib'
 ]
 
 const exclusiveLabelsMap = new Map([
@@ -114,6 +115,7 @@ const exclusiveLabelsMap = new Map([
   [/^test\/cctest\/test_url/, ['test', 'url-whatwg']],
   [/^test\/addons-napi\//, ['test', 'n-api']],
   [/^test\/async-hooks\//, ['test', 'async_hooks']],
+  [/^test\/report\//, ['test', 'report']],
 
   [/^test\//, 'test'],
 

--- a/test/unit/node-labels.test.js
+++ b/test/unit/node-labels.test.js
@@ -629,4 +629,26 @@ tap.test('label: "build" when ./android-configure has been changed', (t) => {
       t.end()
     })
   }
+});
+
+[
+  [ ['c++', 'report'],
+    ['src/node_report.cc',
+     'src/node_report.h',
+     'src/node_report_module.cc',
+     'src/node_report_utils.cc'] ],
+  [ ['doc', 'report'], ['doc/api/report.md'] ],
+  [ ['test', 'report'], ['test/report/test-report-config.js'] ]
+].forEach((info) => {
+  const labels = info[0]
+  const files = info[1]
+  for (const file of files) {
+    tap.test(`label: "${labels.join('","')}" when ./${file} has been changed`, (t) => {
+      const resolved = nodeLabels.resolveLabels([file])
+
+      t.same(resolved, labels)
+
+      t.end()
+    })
+  }
 })


### PR DESCRIPTION
I've found that we need to add `report` label to these PRs manually now.

> https://github.com/nodejs/node/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc+label%3Areport