### PR TITLE
Cache npm dependencies in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - 8
+cache: npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: node_js
 node_js:
   - 8


### PR DESCRIPTION
While looking for some low hanging chores to do, I stumbled upon `.travis.yml`. Thought we might as well tell Travis to cache the npm dependencies to speed up our builds.

Knowing we've got the entire dependency tree locked down with `package-lock.json`, it can't hurt to cache them, right?

Refs https://docs.travis-ci.com/user/caching/#npm-cache

/cc @nodejs/github-bot 