### PR TITLE
Improve integration tests for pushing Jenkins statuses

### DIFF
--- a/lib/push-jenkins-update.js
+++ b/lib/push-jenkins-update.js
@@ -4,7 +4,7 @@ const url = require('url')
 
 const githubClient = require('./github-client')
 
-function pushStarted (options, build) {
+function pushStarted (options, build, cb) {
   const pr = findPrInRef(build.ref)
 
   // create unique logger which is easily traceable for every subsequent log statement
@@ -15,7 +15,9 @@ function pushStarted (options, build) {
 
   findLatestCommitInPr(optsWithPr, (err, latestCommit) => {
     if (err) {
-      return logger.error(err, 'Got error when retrieving GitHub commits for PR')
+      logger.error(err, 'Got error when retrieving GitHub commits for PR')
+      cb(err)
+      return
     }
 
     const statusOpts = Object.assign({
@@ -26,11 +28,11 @@ function pushStarted (options, build) {
       message: build.message || 'running tests'
     }, options)
 
-    createGhStatus(statusOpts, logger)
+    createGhStatus(statusOpts, logger, cb)
   })
 }
 
-function pushEnded (options, build) {
+function pushEnded (options, build, cb) {
   const pr = findPrInRef(build.ref)
 
   // create unique logger which is easily traceable for every subsequent log statement
@@ -41,7 +43,9 @@ function pushEnded (options, build) {
 
   findLatestCommitInPr(optsWithPr, (err, latestCommit) => {
     if (err) {
-      return logger.error(err, 'Got error when retrieving GitHub commits for PR')
+      logger.error(err, 'Got error when retrieving GitHub commits for PR')
+      cb(err)
+      return
     }
 
     const statusOpts = Object.assign({
@@ -52,7 +56,7 @@ function pushEnded (options, build) {
       message: build.message || 'all tests passed'
     }, options)
 
-    createGhStatus(statusOpts, logger)
+    createGhStatus(statusOpts, logger, cb)
   })
 }
 
@@ -89,7 +93,7 @@ function findLatestCommitInPr (options, cb, pageNumber = 1) {
   })
 }
 
-function createGhStatus (options, logger) {
+function createGhStatus (options, logger, cb) {
   githubClient.repos.createStatus({
     owner: options.owner,
     repo: options.repo,
@@ -100,9 +104,12 @@ function createGhStatus (options, logger) {
     description: options.message
   }, (err, res) => {
     if (err) {
-      return logger.error(err, 'Error while updating Jenkins / GitHub PR status')
+      logger.error(err, 'Error while updating Jenkins / GitHub PR status')
+      cb(err)
+      return
     }
     logger.info('Jenkins / Github PR status updated')
+    cb(null)
   })
 }
 

--- a/scripts/jenkins-status.js
+++ b/scripts/jenkins-status.js
@@ -46,9 +46,10 @@ module.exports = function (app) {
       owner: 'nodejs',
       repo,
       logger: req.log
-    }, req.body)
-
-    res.status(201).end()
+    }, req.body, (err) => {
+      const statusCode = err !== null ? 500 : 201
+      res.status(statusCode).end()
+    })
   })
 
   app.post('/:repo/jenkins/end', (req, res) => {
@@ -75,8 +76,9 @@ module.exports = function (app) {
       owner: 'nodejs',
       repo,
       logger: req.log
-    }, req.body)
-
-    res.status(201).end()
+    }, req.body, (err) => {
+      const statusCode = err !== null ? 500 : 201
+      res.status(statusCode).end()
+    })
   })
 }

--- a/test/integration/push-jenkins-update.test.js
+++ b/test/integration/push-jenkins-update.test.js
@@ -19,7 +19,10 @@ tap.test('Sends POST requests to https://api.github.com/repos/nodejs/node/status
                   .reply(201)
 
   t.plan(1)
-  t.tearDown(() => prCommitsScope.done() && scope.done())
+  t.tearDown(() => {
+    prCommitsScope.done()
+    scope.done()
+  })
 
   supertest(app)
     .post('/node/jenkins/start')
@@ -40,7 +43,10 @@ tap.test('Allows repository name to be provided with URL parameter when pushing 
                   .reply(201)
 
   t.plan(1)
-  t.tearDown(() => prCommitsScope.done() && scope.done())
+  t.tearDown(() => {
+    prCommitsScope.done()
+    scope.done()
+  })
 
   supertest(app)
     .post('/citgm/jenkins/start')

--- a/test/integration/push-jenkins-update.test.js
+++ b/test/integration/push-jenkins-update.test.js
@@ -19,16 +19,14 @@ tap.test('Sends POST requests to https://api.github.com/repos/nodejs/node/status
                   .reply(201)
 
   t.plan(1)
-  t.tearDown(() => {
-    prCommitsScope.done()
-    scope.done()
-  })
 
   supertest(app)
     .post('/node/jenkins/start')
     .send(jenkinsPayload)
     .expect(201)
     .end((err, res) => {
+      prCommitsScope.done()
+      scope.done()
       t.equal(err, null)
     })
 })
@@ -43,16 +41,14 @@ tap.test('Allows repository name to be provided with URL parameter when pushing 
                   .reply(201)
 
   t.plan(1)
-  t.tearDown(() => {
-    prCommitsScope.done()
-    scope.done()
-  })
 
   supertest(app)
     .post('/citgm/jenkins/start')
     .send(jenkinsPayload)
     .expect(201)
     .end((err, res) => {
+      prCommitsScope.done()
+      scope.done()
       t.equal(err, null)
     })
 })
@@ -67,16 +63,14 @@ tap.test('Allows repository name to be provided with URL parameter when pushing 
                   .reply(201)
 
   t.plan(1)
-  t.tearDown(() => {
-    prCommitsScope.done()
-    scope.done()
-  })
 
   supertest(app)
     .post('/citgm/jenkins/end')
     .send(jenkinsPayload)
     .expect(201)
     .end((err, res) => {
+      prCommitsScope.done()
+      scope.done()
       t.equal(err, null)
     })
 })
@@ -96,16 +90,14 @@ tap.test('Forwards payload provided in incoming POST to GitHub status API', (t) 
                   .reply(201)
 
   t.plan(1)
-  t.tearDown(() => {
-    prCommitsScope.done()
-    scope.done()
-  })
 
   supertest(app)
     .post('/node/jenkins/start')
     .send(fixture)
     .expect(201)
     .end((err, res) => {
+      prCommitsScope.done()
+      scope.done()
       t.equal(err, null)
     })
 })

--- a/test/integration/push-jenkins-update.test.js
+++ b/test/integration/push-jenkins-update.test.js
@@ -67,7 +67,10 @@ tap.test('Allows repository name to be provided with URL parameter when pushing 
                   .reply(201)
 
   t.plan(1)
-  t.tearDown(() => prCommitsScope.done() && scope.done())
+  t.tearDown(() => {
+    prCommitsScope.done()
+    scope.done()
+  })
 
   supertest(app)
     .post('/citgm/jenkins/end')
@@ -93,7 +96,10 @@ tap.test('Forwards payload provided in incoming POST to GitHub status API', (t) 
                   .reply(201)
 
   t.plan(1)
-  t.tearDown(() => prCommitsScope.done() && scope.done())
+  t.tearDown(() => {
+    prCommitsScope.done()
+    scope.done()
+  })
 
   supertest(app)
     .post('/node/jenkins/start')


### PR DESCRIPTION
*This is a precursor to fixing #212.*

These changes are primarily done so we can get more reliable integration tests. Previously the incoming requests was responded to, before we knew whether or not the Jenkins status has been successfully pushed to GitHub.

That makes it challenging to know when we can assert what we want to verify in integration tests, as we don't know when the entire operation has finished.

Although the previous approach worked in practise when run in production, it should be just as important to have reliable tests that we can rely on when doing changes going forward.

/cc @nodejs/github-bot 