### PR TITLE
labels: add "worker" label

### DIFF
--- a/lib/node-labels.js
+++ b/lib/node-labels.js
@@ -31,6 +31,7 @@ const subSystemLabelsMap = new Map([
   [/^src\/node_api/, ['c++', 'n-api']],
   [/^src\/node_http2/, ['c++', 'http2', 'dont-land-on-v6.x']],
   [/^src\/node_report/, ['c++', 'report']],
+  [/^src\/node_worker/, ['c++', 'worker']],
 
   // don't label python files as c++
   [/^src\/.+\.py$/, 'lib / src'],
@@ -100,7 +101,7 @@ const jsSubsystemList = [
   'console', 'crypto', 'dgram', 'dns', 'domain', 'events', 'fs', 'http',
   'https', 'http2', 'module', 'net', 'os', 'path', 'process', 'querystring',
   'readline', 'repl', 'report', 'stream', 'string_decoder', 'timers', 'tls',
-  'tty', 'url', 'util', 'v8', 'vm', 'zlib'
+  'tty', 'url', 'util', 'v8', 'vm', 'worker', 'zlib'
 ]
 
 const exclusiveLabelsMap = new Map([
@@ -124,6 +125,8 @@ const exclusiveLabelsMap = new Map([
   // n-api is treated separately since it is not a JS core module but is still
   // considered a subsystem of sorts
   [/^doc\/api\/n-api.md$/, ['doc', 'n-api']],
+  // add worker label to PRs that affect doc/api/worker_threads.md
+  [/^doc\/api\/worker_threads.md$/, ['doc', 'worker']],
   // automatically tag JS subsystem-specific API doc changes
   [/^doc\/api\/(\w+)\.md$/, ['doc', '$1']],
   // add deprecations label to PRs that affect doc/api/deprecations.md

--- a/lib/node-labels.js
+++ b/lib/node-labels.js
@@ -89,6 +89,7 @@ const subSystemLabelsMap = new Map([
   [/^lib\/\w+\/socket_list/, 'net'],
   [/^lib\/\w+\/streams$/, 'stream'],
   [/^lib\/.*http2/, ['http2', 'dont-land-on-v6.x']],
+  [/^lib\/worker_threads.js$/, ['worker']],
   [/^lib\/internal\/url\.js$/, ['url-whatwg']],
   // All other lib/ files map directly
   [/^lib\/_(\w+)_\w+\.js?$/, '$1'], // e.g. _(stream)_wrap

--- a/test/unit/node-labels.test.js
+++ b/test/unit/node-labels.test.js
@@ -665,7 +665,8 @@ tap.test('label: "build" when ./android-configure has been changed', (t) => {
 
 [
   [ ['worker'],
-    ['lib/internal/worker.js',
+    ['lib/worker_threads.js',
+     'lib/internal/worker.js',
      'lib/internal/worker/io.js'] ],
   [ ['c++', 'worker'],
     ['src/node_worker.cc',

--- a/test/unit/node-labels.test.js
+++ b/test/unit/node-labels.test.js
@@ -661,4 +661,26 @@ tap.test('label: "build" when ./android-configure has been changed', (t) => {
       t.end()
     })
   }
+});
+
+[
+  [ ['worker'],
+    ['lib/internal/worker.js',
+     'lib/internal/worker/io.js'] ],
+  [ ['c++', 'worker'],
+    ['src/node_worker.cc',
+     'src/node_worker.h'] ],
+  [ ['doc', 'worker'], ['doc/api/worker_threads.md'] ]
+].forEach((info) => {
+  const labels = info[0]
+  const files = info[1]
+  for (const file of files) {
+    tap.test(`label: "${labels.join('","')}" when ./${file} has been changed`, (t) => {
+      const resolved = nodeLabels.resolveLabels([file])
+
+      t.same(resolved, labels)
+
+      t.end()
+    })
+  }
 })


### PR DESCRIPTION
The PRs affected `worker` module need to be labeled manually at present.

Refs: https://github.com/nodejs/node/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc+label%3Aworker