### PR TITLE
Post CI comment in PR for node-test-pull-request builds

### DIFF
--- a/lib/github-comment.js
+++ b/lib/github-comment.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const githubClient = require('./github-client')
+
+exports.createPrComment = function createPrComment ({ owner, repo, number, logger }, body) {
+  githubClient.issues.createComment({
+    owner,
+    repo,
+    number,
+    body
+  }, (err) => {
+    if (err) {
+      logger.error(err, 'Error while creating comment on GitHub')
+    }
+  })
+}

--- a/lib/push-jenkins-update.js
+++ b/lib/push-jenkins-update.js
@@ -14,7 +14,7 @@ function pushStarted (options, build, cb) {
 
   const optsWithPr = Object.assign({ pr }, options)
 
-  if (build.identifier === 'node-test-pull-request') {
+  if (build.identifier === 'node-test-pull-request' && build.status === 'pending') {
     createPrComment(Object.assign({ number: pr }, options), `CI: ${build.url}`)
   }
 

--- a/lib/push-jenkins-update.js
+++ b/lib/push-jenkins-update.js
@@ -3,6 +3,7 @@
 const url = require('url')
 
 const githubClient = require('./github-client')
+const { createPrComment } = require('./github-comment')
 
 function pushStarted (options, build, cb) {
   const pr = findPrInRef(build.ref)
@@ -12,6 +13,10 @@ function pushStarted (options, build, cb) {
   const logger = options.logger.child(traceFields, true)
 
   const optsWithPr = Object.assign({ pr }, options)
+
+  if (build.identifier === 'node-test-pull-request') {
+    createPrComment(Object.assign({ number: pr }, options), `CI: ${build.url}`)
+  }
 
   findLatestCommitInPr(optsWithPr, (err, latestCommit) => {
     if (err) {

--- a/scripts/trigger-jenkins-build.js
+++ b/scripts/trigger-jenkins-build.js
@@ -4,6 +4,7 @@ const request = require('request')
 
 const githubClient = require('../lib/github-client')
 const botUsername = require('../lib/bot-username')
+const { createPrComment } = require('../lib/github-comment')
 
 const jenkinsApiCredentials = process.env.JENKINS_API_CREDENTIALS || ''
 
@@ -82,19 +83,6 @@ function triggerBuild (options, cb) {
 
     cb(null,
       `https://ci.nodejs.org/blue/organizations/jenkins/${jobName}/detail/${jobName}/${response.body.id}/pipeline`)
-  })
-}
-
-function createPrComment ({ owner, repo, number, logger }, body) {
-  githubClient.issues.createComment({
-    owner,
-    repo,
-    number,
-    body
-  }, (err) => {
-    if (err) {
-      logger.error(err, 'Error while creating comment to reply on CI run comment')
-    }
   })
 }
 

--- a/test/_fixtures/jenkins-test-pull-request-success-payload.json
+++ b/test/_fixtures/jenkins-test-pull-request-success-payload.json
@@ -1,7 +1,7 @@
 {
   "identifier": "node-test-pull-request",
-  "status": "success",
-  "message": "tests passed",
+  "status": "pending",
+  "message": "running tests",
   "commit": "8a5fec2a6bade91e544a30314d7cf21f8a200de1",
   "url": "https://ci.nodejs.org/job/node-test-pull-request/21633/",
   "ref": "refs/pull/12345/head"

--- a/test/_fixtures/jenkins-test-pull-request-success-payload.json
+++ b/test/_fixtures/jenkins-test-pull-request-success-payload.json
@@ -1,0 +1,8 @@
+{
+  "identifier": "node-test-pull-request",
+  "status": "success",
+  "message": "tests passed",
+  "commit": "8a5fec2a6bade91e544a30314d7cf21f8a200de1",
+  "url": "https://ci.nodejs.org/job/node-test-pull-request/21633/",
+  "ref": "refs/pull/12345/head"
+}

--- a/test/integration/push-jenkins-update.test.js
+++ b/test/integration/push-jenkins-update.test.js
@@ -117,13 +117,13 @@ tap.test('Posts a CI comment in the related PR when Jenkins build is named node-
     .reply(201)
 
   t.plan(1)
-  t.tearDown(() => commentScope.done())
 
   supertest(app)
     .post('/node/jenkins/start')
     .send(fixture)
     .expect(201)
     .end((err, res) => {
+      commentScope.done()
       t.equal(err, null)
     })
 })


### PR DESCRIPTION
These changes posts a CI style comment to PR's whenever Jenkins reports that node-test-pull-request builds has started.

Closes https://github.com/nodejs/github-bot/issues/212

/cc @nodejs/github-bot 

*P.S. temporary non-master base branch as these changes builds on https://github.com/nodejs/github-bot/pull/222.*