### PR TITLE
Destructure Jenkins build result after knowing it's not an error

### DIFF
--- a/scripts/trigger-jenkins-build.js
+++ b/scripts/trigger-jenkins-build.js
@@ -82,15 +82,18 @@ function triggerBuildIfValid (options) {
       return logger.debug(`Ignoring comment to me by @${options.author} because they are not a repo collaborator`)
     }
 
-    triggerBuild(options, function onBuildTriggered (err, { jobName, jobId }) {
-      const jobUrl = `https://ci.nodejs.org/job/${jobName}/${jobId}`
-      let body = `Lite-CI: ${jobUrl}`
+    triggerBuild(options, function onBuildTriggered (err, result) {
+      let body = ''
+
       if (err) {
         logger.error(err, 'Error while triggering Jenkins build')
         body = 'Sadly, an error occurred when I tried to trigger a build. :('
       } else {
+        const jobUrl = `https://ci.nodejs.org/job/${result.jobName}/${result.jobId}`
         logger.info({ jobUrl }, 'Jenkins build started')
+        body = `Lite-CI: ${jobUrl}`
       }
+
       createPrComment(options, body)
     })
   })


### PR DESCRIPTION
We've seen some error logs in production suggesting that we get errors back from Jenkins when triggering builds, as the result is `null | undefined`. Destructuring fields out of that result causes unchaught exceptions, meaning the bot process dies.

Therefore postponing the destructuring until we're confident the build didn't result in an error.

/cc @nodejs/github-bot @richardlau

Refs https://github.com/nodejs/github-bot/issues/235