### PR TITLE
Don't post PR comment on errors when triggering Lite-CI

### DIFF
--- a/scripts/trigger-jenkins-build.js
+++ b/scripts/trigger-jenkins-build.js
@@ -83,18 +83,13 @@ function triggerBuildIfValid (options) {
     }
 
     triggerBuild(options, function onBuildTriggered (err, result) {
-      let body = ''
-
       if (err) {
-        logger.error(err, 'Error while triggering Jenkins build')
-        body = 'Sadly, an error occurred when I tried to trigger a build. :('
-      } else {
-        const jobUrl = `https://ci.nodejs.org/job/${result.jobName}/${result.jobId}`
-        logger.info({ jobUrl }, 'Jenkins build started')
-        body = `Lite-CI: ${jobUrl}`
+        return logger.error(err, 'Error while triggering Jenkins build')
       }
 
-      createPrComment(options, body)
+      const jobUrl = `https://ci.nodejs.org/job/${result.jobName}/${result.jobId}`
+      logger.info({ jobUrl }, 'Jenkins build started')
+      createPrComment(options, `Lite-CI: ${jobUrl}`)
     })
   })
 }


### PR DESCRIPTION
As the bot does not have permission to trigger Jenkins Lite-CI builds for some reason at the moment, and there's feedback about these error comments not being useful to collaborators anyways, those comments are muted for now.

Ideally github-bot maintainers should get notified about these errors, as they're obviously not meant to be raised at all. But using node core collaborators as proxy, manually telling bot maintainers about errors surely isn't ideal either.

Refs https://github.com/nodejs/github-bot/issues/238
Refs https://github.com/nodejs/github-bot/issues/235#issuecomment-500659506

/cc @nodejs/github-bot @cjihrig @sam-github 