### PR TITLE
jenkins: check successful response before reading

### DIFF
--- a/lib/push-jenkins-update.js
+++ b/lib/push-jenkins-update.js
@@ -89,11 +89,11 @@ function findLatestCommitInPr (options, cb, pageNumber = 1) {
     page: pageNumber,
     per_page: 100
   }, (err, res) => {
-    const commitMetas = res.data || []
     if (err) {
       return cb(err)
     }
 
+    const commitMetas = res.data || []
     const lastPageURL = githubClient.hasLastPage(res)
     if (lastPageURL) {
       return findLatestCommitInPr(options, cb, pageNumberFromURL(lastPageURL))


### PR DESCRIPTION
*FYI PR that gets merged ASAP because of its trivialness.*

While having a look at recent error logs, this fatal log stood out:

```
02:48:11.721 FATAL bot: Unchaught exception, terminating bot process immediately
    TypeError: Cannot read property 'data' of undefined
        at githubClient.pullRequests.getCommits (/.../github-bot/lib/push-jenkins-update.js:92:29)
        at module.exports.sendError (/.../github-bot/node_modules/github/lib/index.js:874:7)
        at /.../github-bot/node_modules/github/lib/index.js:882:21
        at callCallback (/.../github-bot/node_modules/github/lib/index.js:738:9)
        at IncomingMessage.<anonymous> (/.../github-bot/node_modules/github/lib/index.js:807:13)
        at IncomingMessage.emit (events.js:194:15)
        at endReadableNT (_stream_readable.js:1125:12)
        at process._tickCallback (internal/process/next_tick.js:63:19)
```

Since we never want these kinds of errors to happen since they end up killing the bot process, this fix is pushed to ensure we don't naively read the response from github.com until we know the request didn't fail for some reason.

