### PR TITLE
labels: add ES Modules

### DIFF
--- a/lib/node-labels.js
+++ b/lib/node-labels.js
@@ -91,6 +91,7 @@ const subSystemLabelsMap = new Map([
   [/^lib\/.*http2/, ['http2', 'dont-land-on-v6.x']],
   [/^lib\/worker_threads.js$/, ['worker']],
   [/^lib\/internal\/url\.js$/, ['url-whatwg']],
+  [/^lib\/internal\/modules\/esm/, 'ES Modules'],
   // All other lib/ files map directly
   [/^lib\/_(\w+)_\w+\.js?$/, '$1'], // e.g. _(stream)_wrap
   [/^lib(\/internal)?\/(\w+)\.js?$/, '$2'], // other .js files
@@ -99,7 +100,7 @@ const subSystemLabelsMap = new Map([
 
 const jsSubsystemList = [
   'debugger', 'assert', 'async_hooks', 'buffer', 'child_process', 'cluster',
-  'console', 'crypto', 'dgram', 'dns', 'domain', 'events', 'fs', 'http',
+  'console', 'crypto', 'dgram', 'dns', 'domain', 'events', 'esm', 'fs', 'http',
   'https', 'http2', 'module', 'net', 'os', 'path', 'process', 'querystring',
   'readline', 'repl', 'report', 'stream', 'string_decoder', 'timers', 'tls',
   'tty', 'url', 'util', 'v8', 'vm', 'worker', 'zlib'
@@ -118,11 +119,15 @@ const exclusiveLabelsMap = new Map([
   [/^test\/addons-napi\//, ['test', 'n-api']],
   [/^test\/async-hooks\//, ['test', 'async_hooks']],
   [/^test\/report\//, ['test', 'report']],
+  [/^test\/fixtures\/es-module/, ['test', 'ES Modules']],
+  [/^test\/es-module\//, ['test', 'ES Modules']],
 
   [/^test\//, 'test'],
 
   // specific map for modules.md as it should be labeled 'module' not 'modules'
   [/^doc\/api\/modules.md$/, ['doc', 'module']],
+  // specific map for esm.md as it should be labeled 'ES Modules' not 'esm'
+  [/^doc\/api\/esm.md$/, ['doc', 'ES Modules']],
   // n-api is treated separately since it is not a JS core module but is still
   // considered a subsystem of sorts
   [/^doc\/api\/n-api.md$/, ['doc', 'n-api']],


### PR DESCRIPTION
Resolves: https://github.com/nodejs/modules/issues/460

Perhaps changing the name of this label to `esm` would save effort in the long run.

/cc @MylesBorins