### PR TITLE
label: mark all quic change as `dont-land-v14.x`

### DIFF
--- a/lib/node-labels.js
+++ b/lib/node-labels.js
@@ -33,8 +33,8 @@ const subSystemLabelsMap = new Map([
   [/^src\/node_report/, ['c++', 'report']],
   [/^src\/node_wasi/, ['c++', 'wasi']],
   [/^src\/node_worker/, ['c++', 'worker']],
-  [/^src\/quic\/*/, ['c++', 'quic']],
-  [/^src\/node_bob*/, ['c++', 'quic']],
+  [/^src\/quic\/*/, ['c++', 'quic', 'dont-land-on-v14.x', 'dont-land-on-v12.x']],
+  [/^src\/node_bob*/, ['c++', 'quic', 'dont-land-on-v14.x', 'dont-land-on-v12.x']],
 
   // don't label python files as c++
   [/^src\/.+\.py$/, 'lib / src'],
@@ -80,8 +80,8 @@ const subSystemLabelsMap = new Map([
   [/^deps\/uvwasi\//, 'wasi'],
   [/^deps\/nghttp2\/nghttp2\.gyp/, ['build', 'http2', 'dont-land-on-v6.x']],
   [/^deps\/nghttp2\//, ['http2', 'dont-land-on-v6.x']],
-  [/^deps\/ngtcp2\//, 'quic'],
-  [/^deps\/nghttp3\//, 'quic'],
+  [/^deps\/ngtcp2\//, 'quic', 'dont-land-on-v14.x', 'dont-land-on-v12.x'],
+  [/^deps\/nghttp3\//, 'quic', 'dont-land-on-v14.x', 'dont-land-on-v12.x'],
   [/^deps\/([^/]+)/, '$1'],
 
   /* JS subsystems */
@@ -98,7 +98,7 @@ const subSystemLabelsMap = new Map([
   [/^lib\/worker_threads.js$/, ['worker']],
   [/^lib\/internal\/url\.js$/, ['url-whatwg']],
   [/^lib\/internal\/modules\/esm/, 'ES Modules'],
-  [/^lib\/internal\/quic\/*/, ['quic']],
+  [/^lib\/internal\/quic\/*/, ['quic', 'dont-land-on-v14.x', 'dont-land-on-v12.x']],
   // All other lib/ files map directly
   [/^lib\/_(\w+)_\w+\.js?$/, '$1'], // e.g. _(stream)_wrap
   [/^lib(\/internal)?\/(\w+)\.js?$/, '$2'], // other .js files
@@ -139,7 +139,7 @@ const exclusiveLabelsMap = new Map([
   // considered a subsystem of sorts
   [/^doc\/api\/n-api.md$/, ['doc', 'n-api']],
   // quic
-  [/^doc\/api\/quic.md$/, ['doc', 'quic']],
+  [/^doc\/api\/quic.md$/, ['doc', 'quic', 'dont-land-on-v14.x', 'dont-land-on-v12.x']],
   // add worker label to PRs that affect doc/api/worker_threads.md
   [/^doc\/api\/worker_threads.md$/, ['doc', 'worker']],
   // automatically tag JS subsystem-specific API doc changes


### PR DESCRIPTION
As per discussion on GitHub it does not appear that QUIC is intended
to be backported to v14.x, add appropriate label.

/cc @jasnell to confirm