### PR TITLE
feat: upgrade octokit to 16

### DIFF
--- a/lib/node-repo.js
+++ b/lib/node-repo.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const LRU = require('lru-cache')
-const retry = require('async').retry
 const Aigle = require('aigle')
 const request = require('request')
 
@@ -21,30 +20,22 @@ async function deferredResolveLabelsThenUpdatePr (options) {
   return resolveLabelsThenUpdatePr(options)
 }
 
-function resolveLabelsThenUpdatePr (options) {
+async function resolveLabelsThenUpdatePr (options) {
+  const times = options.retries || 5
+  const interval = options.retryInterval || fiveSeconds
+  const retry = fn => Aigle.retry({ times, interval }, fn)
+
+  const filepathsChanged = await retry(() => listFiles({
+    owner: options.owner,
+    repo: options.repo,
+    number: options.prId,
+    logger: options.logger
+  }))
   options.logger.debug('Fetching PR files for labelling')
 
-  const listFiles = (cb) => {
-    githubClient.pullRequests.listFiles({
-      owner: options.owner,
-      repo: options.repo,
-      number: options.prId
-    }, cb)
-  }
+  const resolvedLabels = resolveLabels(filepathsChanged, options.baseBranch)
 
-  return new Promise((resolve, reject) => {
-    retry({ times: 5, interval: fiveSeconds }, listFiles, (err, res) => {
-      if (err) {
-        options.logger.error(err, 'Error retrieving files from GitHub')
-        return reject(err)
-      }
-
-      const filepathsChanged = res.data.map((fileMeta) => fileMeta.filename)
-      const resolvedLabels = resolveLabels(filepathsChanged, options.baseBranch)
-
-      resolve(fetchExistingThenUpdatePr(options, resolvedLabels))
-    })
-  })
+  return fetchExistingThenUpdatePr(options, resolvedLabels)
 }
 
 async function fetchExistingThenUpdatePr (options, labels) {

--- a/lib/node-repo.js
+++ b/lib/node-repo.js
@@ -83,10 +83,10 @@ async function updatePrWithLabels (options, labels) {
   }
 }
 
-function removeLabelFromPR (options, label) {
+function removeLabelFromPR (options, label, cb) {
   // no need to request github if we didn't resolve a label
   if (!label) {
-    return
+    return cb()
   }
 
   options.logger.debug('Trying to remove label: ' + label)
@@ -99,11 +99,12 @@ function removeLabelFromPR (options, label) {
   }, (err) => {
     if (err) {
       if (err.code === 404) return options.logger.info('Label to remove did not exist, bailing ' + label)
-
-      return options.logger.error(err, 'Error while removing a label')
+      options.logger.error(err, 'Error while removing a label')
+      return cb(err, null)
     }
 
     options.logger.info('Removed a label ' + label)
+    return cb(null, label)
   })
 }
 

--- a/lib/node-repo.js
+++ b/lib/node-repo.js
@@ -149,11 +149,7 @@ function getBotPrLabels (options, cb) {
     page: 1,
     per_page: 100, // we probably won't hit this
     number: options.prId
-  }, (err, res) => {
-    if (err) {
-      return cb(err)
-    }
-
+  }).then(res => {
     const events = res.data || []
     const ourLabels = []
 
@@ -174,7 +170,7 @@ function getBotPrLabels (options, cb) {
     }
 
     cb(null, ourLabels)
-  })
+  }, cb)
 }
 
 function stringsInCommon (arr1, arr2) {

--- a/lib/node-repo.js
+++ b/lib/node-repo.js
@@ -74,29 +74,32 @@ async function updatePrWithLabels (options, labels) {
   }
 }
 
-function removeLabelFromPR (options, label, cb) {
+async function removeLabelFromPR (options, label) {
   // no need to request github if we didn't resolve a label
   if (!label) {
-    return cb()
+    return
   }
 
   options.logger.debug('Trying to remove label: ' + label)
 
-  githubClient.issues.removeLabel({
-    owner: options.owner,
-    repo: options.repo,
-    number: options.prId,
-    name: label
-  }, (err) => {
-    if (err) {
-      if (err.code === 404) return options.logger.info('Label to remove did not exist, bailing ' + label)
-      options.logger.error(err, 'Error while removing a label')
-      return cb(err, null)
+  try {
+    await githubClient.issues.removeLabel({
+      owner: options.owner,
+      repo: options.repo,
+      number: options.prId,
+      name: label
+    })
+  } catch (err) {
+    if (err.code === 404) {
+      options.logger.info('Label to remove did not exist, bailing ' + label)
+      throw err
     }
+    options.logger.error(err, 'Error while removing a label')
+    throw err
+  }
 
-    options.logger.info('Removed a label ' + label)
-    return cb(null, label)
-  })
+  options.logger.info('Removed a label ' + label)
+  return label
 }
 
 async function fetchExistingLabels (options) {

--- a/lib/push-jenkins-update.js
+++ b/lib/push-jenkins-update.js
@@ -44,7 +44,7 @@ function pushStarted (options, build, cb) {
       message: build.message || 'running tests'
     }, options)
 
-    createGhStatus(statusOpts, logger, cb)
+    createGhStatus(statusOpts, logger).then(cb).catch(cb)
   })
 }
 
@@ -109,24 +109,22 @@ function findLatestCommitInPr (options, cb, pageNumber = 1) {
   })
 }
 
-function createGhStatus (options, logger, cb) {
-  githubClient.repos.createStatus({
-    owner: options.owner,
-    repo: options.repo,
-    sha: options.sha,
-    target_url: options.url,
-    context: options.context,
-    state: options.state,
-    description: options.message
-  }, (err, res) => {
-    if (err) {
-      logger.error(err, 'Error while updating Jenkins / GitHub PR status')
-      cb(err)
-      return
-    }
-    logger.info('Jenkins / Github PR status updated')
-    cb(null)
-  })
+async function createGhStatus (options, logger) {
+  try {
+    await githubClient.repos.createStatus({
+      owner: options.owner,
+      repo: options.repo,
+      sha: options.sha,
+      target_url: options.url,
+      context: options.context,
+      state: options.state,
+      description: options.message
+    })
+  } catch (err) {
+    logger.error(err, 'Error while updating Jenkins / GitHub PR status')
+    throw err
+  }
+  logger.info('Jenkins / Github PR status updated')
 }
 
 function validate (payload) {

--- a/lib/push-jenkins-update.js
+++ b/lib/push-jenkins-update.js
@@ -29,13 +29,7 @@ function pushStarted (options, build, cb) {
     }
   }
 
-  findLatestCommitInPr(optsWithPr, (err, latestCommit) => {
-    if (err) {
-      logger.error(err, 'Got error when retrieving GitHub commits for PR')
-      cb(err)
-      return
-    }
-
+  findLatestCommitInPr(optsWithPr).then(latestCommit => {
     const statusOpts = Object.assign({
       sha: latestCommit.sha,
       url: build.url,
@@ -45,6 +39,9 @@ function pushStarted (options, build, cb) {
     }, options)
 
     createGhStatus(statusOpts, logger).then(cb).catch(cb)
+  }, err => {
+    logger.error(err, 'Got error when retrieving GitHub commits for PR')
+    return cb(err)
   })
 }
 
@@ -57,13 +54,7 @@ function pushEnded (options, build, cb) {
 
   const optsWithPr = Object.assign({ pr }, options)
 
-  findLatestCommitInPr(optsWithPr, (err, latestCommit) => {
-    if (err) {
-      logger.error(err, 'Got error when retrieving GitHub commits for PR')
-      cb(err)
-      return
-    }
-
+  findLatestCommitInPr(optsWithPr).then(latestCommit => {
     const statusOpts = Object.assign({
       sha: latestCommit.sha,
       url: build.url,
@@ -72,7 +63,10 @@ function pushEnded (options, build, cb) {
       message: build.message || 'all tests passed'
     }, options)
 
-    createGhStatus(statusOpts, logger, cb)
+    createGhStatus(statusOpts, logger).then(cb, cb)
+  }, err => {
+    logger.error(err, 'Got error when retrieving GitHub commits for PR')
+    return cb(err)
   })
 }
 
@@ -81,32 +75,27 @@ function findPrInRef (gitRef) {
   return parseInt(gitRef.split('/')[2], 10)
 }
 
-function findLatestCommitInPr (options, cb, pageNumber = 1) {
-  githubClient.pullRequests.listCommits({
+async function findLatestCommitInPr (options, pageNumber = 1) {
+  const res = await githubClient.pullRequests.listCommits({
     owner: options.owner,
     repo: options.repo,
     number: options.pr,
     page: pageNumber,
     per_page: 100
-  }, (err, res) => {
-    if (err) {
-      return cb(err)
-    }
-
-    const commitMetas = res.data || []
-    const lastPageURL = githubClient.hasLastPage(res)
-    if (lastPageURL) {
-      return findLatestCommitInPr(options, cb, pageNumberFromURL(lastPageURL))
-    }
-
-    const lastCommitMeta = commitMetas.pop()
-    const lastCommit = {
-      sha: lastCommitMeta.sha,
-      date: lastCommitMeta.commit.committer.date
-    }
-
-    cb(null, lastCommit)
   })
+
+  const commitMetas = res.data || []
+  const lastPageURL = githubClient.hasLastPage(res)
+  if (lastPageURL) {
+    return findLatestCommitInPr(options, pageNumberFromURL(lastPageURL))
+  }
+  const lastCommitMeta = commitMetas.pop()
+  const lastCommit = {
+    sha: lastCommitMeta.sha,
+    date: lastCommitMeta.commit.committer.date
+  }
+
+  return lastCommit
 }
 
 async function createGhStatus (options, logger) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -150,35 +150,154 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@octokit/rest": {
-      "version": "15.18.3",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.18.3.tgz",
-      "integrity": "sha512-oHABAvvC83tPIuvUfWRaw9eLThFrCxBgywl+KvEwfTFjoCrMOfEaMh0r39+Ub/EEbV345GJiMzN+zPZ4kqOvbA==",
+    "@octokit/auth-token": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
+      "integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
       "requires": {
-        "before-after-hook": "^1.1.0",
-        "btoa-lite": "^1.0.0",
-        "debug": "^3.1.0",
-        "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^2.2.0",
-        "lodash": "^4.17.4",
-        "node-fetch": "^2.1.1",
-        "universal-user-agent": "^2.0.0",
-        "url-template": "^2.0.8"
+        "@octokit/types": "^5.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.5.tgz",
+      "integrity": "sha512-70K5u6zd45ItOny6aHQAsea8HHQjlQq85yqOMe+Aj8dkhN2qSJ9T+Q3YjUjEYfPRBcuUWNgMn62DQnP/4LAIiQ==",
+      "requires": {
+        "@octokit/types": "^5.0.0",
+        "is-plain-object": "^4.0.0",
+        "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+        "universal-user-agent": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+          "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+        }
+      }
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-1.1.2.tgz",
+      "integrity": "sha512-jbsSoi5Q1pj63sC16XIUboklNw+8tL9VOnJsWycWYR78TKss5PVpIPb1TUUcMQ+bBh7cY579cVAWmf5qG+dw+Q==",
+      "requires": {
+        "@octokit/types": "^2.0.1"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "2.16.2",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
+          "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
           "requires": {
-            "ms": "^2.1.1"
+            "@types/node": ">= 8"
+          }
+        }
+      }
+    },
+    "@octokit/plugin-request-log": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz",
+      "integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw=="
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-2.4.0.tgz",
+      "integrity": "sha512-EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==",
+      "requires": {
+        "@octokit/types": "^2.0.1",
+        "deprecation": "^2.3.1"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "2.16.2",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
+          "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
+          "requires": {
+            "@types/node": ">= 8"
+          }
+        }
+      }
+    },
+    "@octokit/request": {
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.7.tgz",
+      "integrity": "sha512-FN22xUDP0i0uF38YMbOfx6TotpcENP5W8yJM1e/LieGXn6IoRxDMnBf7tx5RKSW4xuUZ/1P04NFZy5iY3Rax1A==",
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^5.0.0",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^4.0.0",
+        "node-fetch": "^2.3.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "@octokit/request-error": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
+          "integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
+          "requires": {
+            "@octokit/types": "^5.0.1",
+            "deprecation": "^2.0.0",
+            "once": "^1.4.0"
           }
         },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        "universal-user-agent": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+          "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
         }
+      }
+    },
+    "@octokit/request-error": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.1.tgz",
+      "integrity": "sha512-+6yDyk1EES6WK+l3viRDElw96MvwfJxCt45GvmjDUKWjYIb3PJZQkq3i46TwGwoPD4h8NmTrENmtyA1FwbmhRA==",
+      "requires": {
+        "@octokit/types": "^2.0.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "2.16.2",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
+          "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
+          "requires": {
+            "@types/node": ">= 8"
+          }
+        }
+      }
+    },
+    "@octokit/rest": {
+      "version": "16.43.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.43.2.tgz",
+      "integrity": "sha512-ngDBevLbBTFfrHZeiS7SAMAZ6ssuVmXuya+F/7RaVvlysgGa1JKJkKWY+jV6TCJYcW0OALfJ7nTIGXcBXzycfQ==",
+      "requires": {
+        "@octokit/auth-token": "^2.4.0",
+        "@octokit/plugin-paginate-rest": "^1.1.1",
+        "@octokit/plugin-request-log": "^1.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "2.4.0",
+        "@octokit/request": "^5.2.0",
+        "@octokit/request-error": "^1.0.2",
+        "atob-lite": "^2.0.0",
+        "before-after-hook": "^2.0.0",
+        "btoa-lite": "^1.0.0",
+        "deprecation": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "lodash.set": "^4.3.2",
+        "lodash.uniq": "^4.5.0",
+        "octokit-pagination-methods": "^1.1.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^4.0.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.4.0.tgz",
+      "integrity": "sha512-D/uotqF69M50OIlwMqgyIg9PuLT2daOiBAYF0P40I2ekFA2ESwwBY5dxZe/UhXdPvIbNKDzuZmQrO7rMpuFbcg==",
+      "requires": {
+        "@types/node": ">= 8"
       }
     },
     "@types/body-parser": {
@@ -287,14 +406,6 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
       "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
       "dev": true
-    },
-    "agent-base": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-      "requires": {
-        "es6-promisify": "^5.0.0"
-      }
     },
     "aigle": {
       "version": "1.14.1",
@@ -474,6 +585,11 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "atob-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+      "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -562,9 +678,9 @@
       }
     },
     "before-after-hook": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
-      "integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
+      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
     },
     "binary-extensions": {
       "version": "2.0.0",
@@ -1281,6 +1397,11 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -1408,19 +1529,6 @@
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "requires": {
-        "es6-promise": "^4.0.3"
-      }
     },
     "escape-goat": {
       "version": "2.1.1",
@@ -2434,25 +2542,6 @@
         "statuses": ">= 1.4.0 < 2"
       }
     },
-    "http-proxy-agent": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-      "requires": {
-        "agent-base": "4",
-        "debug": "3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -2461,30 +2550,6 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
-      }
-    },
-    "https-proxy-agent": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-      "requires": {
-        "agent-base": "^4.3.0",
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
       }
     },
     "iconv-lite": {
@@ -2661,6 +2726,11 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
       "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
       "dev": true
+    },
+    "is-plain-object": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
+      "integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA=="
     },
     "is-promise": {
       "version": "2.1.0",
@@ -3095,6 +3165,21 @@
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "log-driver": {
       "version": "1.2.7",
@@ -3607,6 +3692,11 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
       "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
       "dev": true
+    },
+    "octokit-pagination-methods": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
+      "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -6359,11 +6449,11 @@
       }
     },
     "universal-user-agent": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.1.0.tgz",
-      "integrity": "sha512-8itiX7G05Tu3mGDTdNY2fB4KJ8MgZLS54RdG6PkkfwMAavrXu1mV/lls/GABx9O3Rw4PnTtasxrvbMQoBYY92Q==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.1.tgz",
+      "integrity": "sha512-LnST3ebHwVL2aNe4mejI9IQh2HfZ1RLo8Io2HugSif8ekzD1TlWpHpColOB/eh8JHMLkGH3Akqf040I+4ylNxg==",
       "requires": {
-        "os-name": "^3.0.0"
+        "os-name": "^3.1.0"
       }
     },
     "unpipe": {
@@ -6477,11 +6567,6 @@
       "requires": {
         "prepend-http": "^2.0.0"
       }
-    },
-    "url-template": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
     },
     "util": {
       "version": "0.11.0",
@@ -6603,9 +6688,9 @@
       }
     },
     "windows-release": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.1.tgz",
-      "integrity": "sha512-Pngk/RDCaI/DkuHPlGTdIkDiTAnAkyMjoQMZqRsxydNl1qGXNIoZrB7RK8g53F2tEgQBMqQJHQdYZuQEEAu54A==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.3.tgz",
+      "integrity": "sha512-OSOGH1QYiW5yVor9TtmXKQvt2vjQqbYS+DqmsZw+r7xDwLXEeT3JGW0ZppFmHx4diyXmxt238KFR3N9jzevBRg==",
       "requires": {
         "execa": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "private": true,
   "license": "MIT",
   "dependencies": {
-    "@octokit/rest": "^15.18.3",
+    "@octokit/rest": "^16.43.2",
     "aigle": "^1.14.1",
     "async": "2.1.5",
     "basic-auth": "^1.0.4",

--- a/test/integration/node-labels-webhook.test.js
+++ b/test/integration/node-labels-webhook.test.js
@@ -56,7 +56,7 @@ tap.test('Sends POST request to https://api.github.com/repos/nodejs/node/issues/
 
   const newLabelsScope = nock('https://api.github.com')
     .filteringPath(ignoreQueryParams)
-    .post('/repos/nodejs/node/issues/19/labels', expectedLabels)
+    .post('/repos/nodejs/node/issues/19/labels', { labels: expectedLabels })
     .reply(200)
 
   t.plan(1)
@@ -93,7 +93,7 @@ tap.test('Adds v6.x label when PR is targeting the v6.x-staging branch', (t) => 
 
   const newLabelsScope = nock('https://api.github.com')
     .filteringPath(ignoreQueryParams)
-    .post('/repos/nodejs/node/issues/19/labels', expectedLabels)
+    .post('/repos/nodejs/node/issues/19/labels', { labels: expectedLabels })
     .reply(200)
 
   t.plan(1)
@@ -162,7 +162,7 @@ tap.test('Adds V8 Engine label when PR has deps/v8 file changes', (t) => {
 
   const newLabelsScope = nock('https://api.github.com')
     .filteringPath(ignoreQueryParams)
-    .post('/repos/nodejs/node/issues/9422/labels', expectedLabels)
+    .post('/repos/nodejs/node/issues/9422/labels', { labels: expectedLabels })
     .reply(200)
 
   t.plan(1)

--- a/test/unit/node-repo.test.js
+++ b/test/unit/node-repo.test.js
@@ -133,3 +133,21 @@ tap.test('getBotPrLabels(): returns net labels added/removed by nodejs-github-bo
     scope.done()
   })
 })
+
+tap.test('removeLabelFromPR(): should remove label', (t) => {
+  const owner = 'nodejs'
+  const repo = 'node7'
+  const prId = '3'
+  const label = '3'
+
+  const scope = nock('https://api.github.com')
+    .filteringPath(ignoreQueryParams)
+    .delete(`/repos/${owner}/${repo}/issues/${prId}/labels/${label}`)
+    .reply(200)
+  t.plan(1)
+
+  nodeRepo.removeLabelFromPR({ owner, repo, prId, logger }, label, (_, response) => {
+    t.same(label, response)
+    scope.done()
+  })
+})

--- a/test/unit/node-repo.test.js
+++ b/test/unit/node-repo.test.js
@@ -134,7 +134,7 @@ tap.test('getBotPrLabels(): returns net labels added/removed by nodejs-github-bo
   })
 })
 
-tap.test('removeLabelFromPR(): should remove label', (t) => {
+tap.test('removeLabelFromPR(): should remove label', async (t) => {
   const owner = 'nodejs'
   const repo = 'node7'
   const prId = '3'
@@ -146,8 +146,7 @@ tap.test('removeLabelFromPR(): should remove label', (t) => {
     .reply(200)
   t.plan(1)
 
-  nodeRepo.removeLabelFromPR({ owner, repo, prId, logger }, label, (_, response) => {
-    t.same(label, response)
-    scope.done()
-  })
+  const response = await nodeRepo.removeLabelFromPR({ owner, repo, prId, logger }, label)
+  t.same(label, response)
+  scope.done()
 })

--- a/test/unit/push-jenkins-update.test.js
+++ b/test/unit/push-jenkins-update.test.js
@@ -6,7 +6,7 @@ const nock = require('nock')
 const readFixture = require('../read-fixture')
 const { ignoreQueryParams } = require('../common')
 
-tap.test('findLatestCommitInPr: paginates results when more than 100 commits in a PR', (t) => {
+tap.test('findLatestCommitInPr: paginates results when more than 100 commits in a PR', async (t) => {
   const commitsFixturePage1 = readFixture('pull-requests-commits-page-1.json')
   const commitsFixturePage104 = readFixture('pull-requests-commits-page-104.json')
   const owner = 'nodejs'
@@ -26,16 +26,10 @@ tap.test('findLatestCommitInPr: paginates results when more than 100 commits in 
     .query({ page: 104, per_page: 100, access_token: 'invalid-placeholder-token' })
     .reply(200, commitsFixturePage104)
 
-  t.plan(2)
+  t.plan(1)
 
-  findLatestCommitInPr({
-    owner,
-    repo,
-    pr
-  }, (err, commit) => {
-    t.equal(err, null)
-    t.equal(commit.sha, 'c1aa949064892dbe693750686c06f4ad5673e577')
-    firstPageScope.done()
-    lastPageScope.done()
-  })
+  const commit = await findLatestCommitInPr({ owner, repo, pr })
+  t.equal(commit.sha, 'c1aa949064892dbe693750686c06f4ad5673e577')
+  firstPageScope.done()
+  lastPageScope.done()
 })


### PR DESCRIPTION
Resolved all remaining deprecations on v15 (convert everything to promises because callbacks were removed), upgraded to v16, fixed tests (the payload format of one request changed and nock was not matching it anymore). I already fixed some deprecations on v16, but didn't commit yet so that the PR is not overwhelming. With this PR we'll have access to [createDispatchEvent](https://github.com/octokit/rest.js/releases/tag/v16.29.0), which means it will unblock #272.

P.S.: Each commit converts one callback-based function into Promises/async, so the best way to read this PR is going on each commit individually.