### PR TITLE
Fix deprecated Octokit warnings

### DIFF
--- a/lib/github-client.js
+++ b/lib/github-client.js
@@ -1,18 +1,13 @@
 'use strict'
 
-const GitHub = require('@octokit/rest')
+const { Octokit } = require('@octokit/rest')
 
-const githubClient = new GitHub({
-  version: '3.0.0',
-  timeout: 5 * 1000,
-  headers: {
-    'user-agent': 'Node.js GitHub Bot v1.0-beta'
+const githubClient = new Octokit({
+  auth: process.env.GITHUB_TOKEN || 'invalid-placeholder-token',
+  userAgent: 'Node.js GitHub Bot v1.0-beta',
+  request: {
+    timeout: 5 * 1000
   }
-})
-
-githubClient.authenticate({
-  type: 'oauth',
-  token: process.env.GITHUB_TOKEN || 'invalid-placeholder-token'
 })
 
 module.exports = githubClient

--- a/lib/github-comment.js
+++ b/lib/github-comment.js
@@ -1,13 +1,15 @@
 'use strict'
 
+/* eslint-disable camelcase */
+
 const githubClient = require('./github-client')
 
-exports.createPrComment = async function createPrComment ({ owner, repo, number, logger }, body) {
+exports.createPrComment = async function createPrComment ({ owner, repo, issue_number, logger }, body) {
   try {
     await githubClient.issues.createComment({
       owner,
       repo,
-      number,
+      issue_number,
       body
     })
   } catch (err) {

--- a/lib/node-repo.js
+++ b/lib/node-repo.js
@@ -194,7 +194,7 @@ function getCodeOwnersUrl (owner, repo, defaultBranch) {
 
 async function listFiles ({ owner, repo, number, logger }) {
   try {
-    const response = await githubClient.pullRequests.listFiles({
+    const response = await githubClient.pulls.listFiles({
       owner,
       repo,
       number

--- a/lib/node-repo.js
+++ b/lib/node-repo.js
@@ -1,5 +1,7 @@
 'use strict'
 
+/* eslint-disable camelcase */
+
 const LRU = require('lru-cache')
 const Aigle = require('aigle')
 const request = require('request')
@@ -28,7 +30,7 @@ async function resolveLabelsThenUpdatePr (options) {
   const filepathsChanged = await retry(() => listFiles({
     owner: options.owner,
     repo: options.repo,
-    number: options.prId,
+    pull_number: options.prId,
     logger: options.logger
   }))
   options.logger.debug('Fetching PR files for labelling')
@@ -64,7 +66,7 @@ async function updatePrWithLabels (options, labels) {
     await githubClient.issues.addLabels({
       owner: options.owner,
       repo: options.repo,
-      number: options.prId,
+      issue_number: options.prId,
       labels: labels
     })
 
@@ -86,7 +88,7 @@ async function removeLabelFromPR (options, label) {
     await githubClient.issues.removeLabel({
       owner: options.owner,
       repo: options.repo,
-      number: options.prId,
+      issue_number: options.prId,
       name: label
     })
   } catch (err) {
@@ -148,7 +150,7 @@ function getBotPrLabels (options, cb) {
     repo: options.repo,
     page: 1,
     per_page: 100, // we probably won't hit this
-    number: options.prId
+    issue_number: options.prId
   }).then(res => {
     const events = res.data || []
     const ourLabels = []
@@ -192,12 +194,12 @@ function getCodeOwnersUrl (owner, repo, defaultBranch) {
   return `https://${base}/${owner}/${repo}/${defaultBranch}/${filepath}`
 }
 
-async function listFiles ({ owner, repo, number, logger }) {
+async function listFiles ({ owner, repo, pull_number, logger }) {
   try {
     const response = await githubClient.pulls.listFiles({
       owner,
       repo,
-      number
+      pull_number
     })
     return response.data.map(({ filename }) => filename)
   } catch (err) {
@@ -274,7 +276,7 @@ async function pingOwners (options, owners) {
     await createPrComment({
       owner: options.owner,
       repo: options.repo,
-      number: options.prId,
+      issue_number: options.prId,
       logger: options.logger
     }, getCommentForOwners(owners))
   } catch (err) {

--- a/lib/push-jenkins-update.js
+++ b/lib/push-jenkins-update.js
@@ -17,11 +17,11 @@ function pushStarted (options, build, cb) {
   if (build.status === 'pending') {
     switch (build.identifier) {
       case 'node-test-pull-request':
-        createPrComment(Object.assign({ number: pr }, options), `CI: ${build.url}`)
+        createPrComment(Object.assign({ issue_number: pr }, options), `CI: ${build.url}`)
         break
 
       case 'node-test-pull-request-lite-pipeline':
-        createPrComment(Object.assign({ number: pr }, options), `Lite-CI: ${build.url}`)
+        createPrComment(Object.assign({ issue_number: pr }, options), `Lite-CI: ${build.url}`)
         break
 
       default:
@@ -79,7 +79,7 @@ async function findLatestCommitInPr (options, pageNumber = 1) {
   const res = await githubClient.pulls.listCommits({
     owner: options.owner,
     repo: options.repo,
-    number: options.pr,
+    pull_number: options.pr,
     page: pageNumber,
     per_page: 100
   })

--- a/lib/push-jenkins-update.js
+++ b/lib/push-jenkins-update.js
@@ -76,7 +76,7 @@ function findPrInRef (gitRef) {
 }
 
 async function findLatestCommitInPr (options, pageNumber = 1) {
-  const res = await githubClient.pullRequests.listCommits({
+  const res = await githubClient.pulls.listCommits({
     owner: options.owner,
     repo: options.repo,
     number: options.pr,

--- a/test/unit/node-repo-owners.test.js
+++ b/test/unit/node-repo-owners.test.js
@@ -19,7 +19,7 @@ const options = {
   owner: 'nodejs',
   repo: 'node-auto-test',
   prId: 12345,
-  number: 12345,
+  pull_number: 12345,
   logger: { info: () => {}, error: () => {}, debug: () => {}, child: function () { return this } },
   retries: 1,
   defaultBranch: 'main',

--- a/test/unit/node-repo.test.js
+++ b/test/unit/node-repo.test.js
@@ -83,7 +83,7 @@ tap.test('fetchExistingLabels(): can retrieve more than 100 labels', async (t) =
 
   const secondPageScope = nock('https://api.github.com')
     .get(`/repos/${owner}/${repo}/labels`)
-    .query({ page: 2, per_page: 100, access_token: 'invalid-placeholder-token' })
+    .query({ page: 2, per_page: 100 })
     .reply(200, labelsFixturePage2.data)
 
   t.plan(2)

--- a/test/unit/push-jenkins-update.test.js
+++ b/test/unit/push-jenkins-update.test.js
@@ -23,7 +23,7 @@ tap.test('findLatestCommitInPr: paginates results when more than 100 commits in 
 
   const lastPageScope = nock('https://api.github.com')
     .get(`/repos/${owner}/${repo}/pulls/${pr}/commits`)
-    .query({ page: 104, per_page: 100, access_token: 'invalid-placeholder-token' })
+    .query({ page: 104, per_page: 100 })
     .reply(200, commitsFixturePage104)
 
   t.plan(1)


### PR DESCRIPTION
These changes fixes the majority of deprecation warnings seen when currently running our tests, as can be seen in the last run on `master` branch: [last Travis CI run](https://travis-ci.com/github/nodejs/github-bot/builds/183960087)

Aside from the warnings seen in tests, I'm hoping it'll avoid the deprecation emails we've been getting related to the `?access_token` query parameter used for authentication, since these changes does authentication slightly different (inline with recent [Octokit authentication docs](https://octokit.github.io/rest.js/v16#authentication)).

_P.S. might be worth reviewing each commit separately._

Refs https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param