### PR TITLE
Replace Travis CI with GitHub Actions + more Node.js versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 15.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-node_js:
-  - 10
-cache: npm


### PR DESCRIPTION
Primarily as a precursor to upgrading the Node.js version on the server where @nodejs-github-bot runs from v10 -> v14, running tests on v14 in CI is valuable.

Also added Node.js 15 to the mix as it's worth getting early heads up if there are any upcoming issues before considering an upgrade.

The transition to GitHub Actions is done because it's convenient and there's been significant use of Actions in the Node.js org lately.