### PR TITLE
fix: label doc/api/webcrypto.md as crypto doc

### DIFF
--- a/lib/node-labels.js
+++ b/lib/node-labels.js
@@ -131,6 +131,8 @@ const exclusiveLabelsMap = new Map([
 
   [/^test\//, 'test'],
 
+  // specific map for webcrypto.md as it should be labeled 'crypto'
+  [/^doc\/api\/webcrypto.md$/, ['doc', 'crypto']],
   // specific map for modules.md as it should be labeled 'module' not 'modules'
   [/^doc\/api\/modules.md$/, ['doc', 'module']],
   // specific map for esm.md as it should be labeled 'ES Modules' not 'esm'

--- a/test/unit/node-labels.test.js
+++ b/test/unit/node-labels.test.js
@@ -41,6 +41,16 @@ tap.test('label: "doc" when only ./doc/ files has been changed', (t) => {
   t.end()
 })
 
+tap.test('label: "doc" and "crypto" when webcrypto docs have been changed', (t) => {
+  const labels = nodeLabels.resolveLabels([
+    'doc/api/webcrypto.md'
+  ])
+
+  t.same(labels, ['doc', 'crypto'])
+
+  t.end()
+})
+
 tap.test('label: "doc" & "deprecations" when ./doc/api/deprecations.md has been changed', (t) => {
   const labels = nodeLabels.resolveLabels([
     'doc/api/deprecations.md'


### PR DESCRIPTION
This will make doc updates to webcrypto.md (part of the crypto subsystem) labeled appropriately.