### PR TITLE
Bugfix Jenkins -> GitHub Actions relay by avoiding circular reference

### DIFF
--- a/lib/jenkins-events.js
+++ b/lib/jenkins-events.js
@@ -72,6 +72,8 @@ module.exports = (app, events) => {
     // create unique logger which is easily traceable throughout the entire app
     // by having e.g. "nodejs/nodejs.org/#1337" part of every subsequent log statement
     data.logger = logger.child({ identifier, event }, true)
+    // prevent data.logger from plausibly being serialised to JSON due to circular references
+    Object.defineProperty(data, 'logger', { enumerable: false })
 
     data.logger.info('Emitting Jenkins event')
     debug(data)


### PR DESCRIPTION
Been seeing a lot of these errors lately:

```json
{
  "name": "bot",
  "hostname": "infra-rackspace-debian8-x64-1",
  "pid": 2704,
  "req_id": "081c1880-7883-11eb-88cc-b7c6efa14646",
  "identifier": "node-test-pull-request",
  "event": "end",
  "level": 20,
  "msg": "Relaying jenkins.node-test-pull-request.end to nodejs/node",
  "time": "2021-02-26T22:36:13.705Z",
  "v": 0
}
{
  "name": "bot",
  "hostname": "infra-rackspace-debian8-x64-1",
  "pid": 2704,
  "req_id": "081c1880-7883-11eb-88cc-b7c6efa14646",
  "identifier": "node-test-pull-request",
  "event": "end",
  "level": 50,
  "err": {
    "message": "Converting circular structure to JSON\n    --> starting at object with constructor 'Timeout'\n    |     property '_idlePrev' -> object with constructor 'TimersList'\n    --- property '_idleNext' closes the circle",
    "name": "TypeError",
    "stack": "TypeError: Converting circular structure to JSON\n    --> starting at object with constructor 'Timeout'\n    |     property '_idlePrev' -> object with constructor 'TimersList'\n    --- property '_idleNext' closes the circle\n    at JSON.stringify (<anonymous>)\n    at fetchWrapper (/home/iojs/github-bot/node_modules/@octokit/request/dist-node/index.js:21:32)\n    at request (/home/iojs/github-bot/node_modules/@octokit/request/dist-node/index.js:125:14)\n    at hook (/home/iojs/github-bot/node_modules/@octokit/auth-token/dist-node/index.js:30:10)\n    at /home/iojs/github-bot/node_modules/@octokit/plugin-request-log/dist-node/index.js:18:12\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (internal/process/task_queues.js:93:5)\n    at async AsyncEventEmitter.handleJenkinsRelay (/home/iojs/github-bot/scripts/event-relay.js:10:5)"
  },
  "msg": "Failed to relay jenkins.node-test-pull-request.end to nodejs/node",
  "time": "2021-02-26T22:36:13.708Z",
  "v": 0
}
```

Hinting at some kind of circular reference when serialising into JSON.

Diving into the details of the somewhat recent Jenkins -> GitHub Action relay, the fact that we serialise the `event` object which has a `bunyan` logger instance attached to the `.logger` property, looks like a likely suspect for that kind of circular reference.

https://github.com/nodejs/github-bot/blob/9ef8f375fcab480ded9de880116dbd67193250b2/scripts/event-relay.js#L10-L15

Since there's no value in wanting to include that `.logger` property when serialising the `event` object, or iterating over its fields, explicitly making that field non-enumerable makes sense from a glance.