### PR TITLE
Bugfix for ping repo owners after `@octokit/rest` upgrade

### DIFF
--- a/lib/node-repo.js
+++ b/lib/node-repo.js
@@ -84,12 +84,12 @@ function getCodeOwnersUrl (owner, repo, defaultBranch) {
   return `https://${base}/${owner}/${repo}/${defaultBranch}/${filepath}`
 }
 
-async function listFiles ({ owner, repo, pull_number, logger }) {
+async function listFiles ({ owner, repo, prId, logger }) {
   try {
     const response = await githubClient.pulls.listFiles({
       owner,
       repo,
-      pull_number
+      pull_number: prId
     })
     return response.data.map(({ filename }) => filename)
   } catch (err) {
@@ -133,7 +133,6 @@ async function resolveOwnersThenPingPr (options) {
   const retry = fn => Aigle.retry({ times, interval }, fn)
 
   options.logger.debug('Getting file paths')
-  options.number = options.prId
   const filepathsChanged = await retry(() => listFiles(options))
   options.logger = options.logger.child({ filepathsChanged })
 

--- a/test/unit/node-repo-owners.test.js
+++ b/test/unit/node-repo-owners.test.js
@@ -19,7 +19,6 @@ const options = {
   owner: 'nodejs',
   repo: 'node-auto-test',
   prId: 12345,
-  pull_number: 12345,
   logger: { info: () => {}, error: () => {}, debug: () => {}, child: function () { return this } },
   retries: 1,
   defaultBranch: 'main',


### PR DESCRIPTION
_@mmarchini sorry I didn't realise I had broken this until now.._

Turns out the nodejs/node repo owners functionality has been broken for quite some time. When upgrading `@octokit/rest` and avoiding a deprecation warning back in November 2020, the owners functionality stopped working.

Tracked this down by searching for the latest `Review requested: ..` comment found in nodejs/node, which was one day before the said github-bot changes rolled out.

The culprit seems to the `.number -> .pull_number` transition in https://github.com/nodejs/github-bot/commit/7b4ac859952163479b2afe159cf0ff29416b37bb, especially related to listing changes files in a PR when figuring out which owners to ping.

This microscopic change, removing the `.pull_number` field from the options used in `./test/unit/node-repo-owners.test.js` surfaces the issue and correctly causes tests to break.

`options.pull_number` is NOT part of the options being sent through the code base when a GitHub webhook event is emitted.

By removing that field from the `options` used while testing, certain test expectations didn't pass, which is to be expected because some `./lib/node-repo.js` code had to be adjusted first.