### PR TITLE
fix: use authenticated GitHub client for Jenkins updates

### DIFF
--- a/lib/push-jenkins-update.js
+++ b/lib/push-jenkins-update.js
@@ -78,8 +78,6 @@ function findPrInRef (gitRef) {
 }
 
 async function findLatestCommitInPr (options) {
-  const { Octokit } = require('@octokit/rest')
-  const githubClient = new Octokit({})
   const paginateOptions = githubClient.pulls.listCommits.endpoint.merge({
     owner: options.owner,
     repo: options.repo,


### PR DESCRIPTION
Fixes: https://github.com/nodejs/github-bot/issues/374