### PR TITLE
fix: replace `glob.sync` for glob@9

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@
 
 require('dotenv').config({ silent: true })
 
-const glob = require('glob')
+const { globSync } = require('glob')
 const logger = require('./lib/logger')
 
 const port = process.env.PORT || 3000
@@ -10,7 +10,7 @@ const scriptsToLoad = process.env.SCRIPTS || './scripts/**/*.js'
 const { app, events } = require('./app')
 
 // load all the files in the scripts folder
-glob.sync(scriptsToLoad).forEach((file) => {
+globSync(scriptsToLoad).forEach((file) => {
   logger.info('Loading:', file)
   require(file)(app, events)
 })


### PR DESCRIPTION
glob@9 no longer exports `sync()`.

Fixes: https://github.com/nodejs/github-bot/issues/376
Refs: https://github.com/isaacs/node-glob/issues/493
Refs: https://github.com/nodejs/github-bot/pull/372