### PR TITLE
chore: drop support for Node.js 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test:watch": "nodemon -q -x 'npm test'"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 14.0.0"
   },
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
@octokit/rest no longer supports Node.js 12. Our tests still pass, but our bot runs 14.x, so rather than get caught up some time if 12.x tests ever do start failing, let's drop support now.