### PR TITLE
chore: update engines in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test:watch": "nodemon -q -x 'npm test'"
   },
   "engines": {
-    "node": ">= 14.0.0"
+    "node": ">= 20.0.0"
   },
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
We are now running github-bot on Node.js 20 so let's stop testing on 14.x so we can update some packages that we've been holding off on.

Please don't land this. Let @richardlau land it. We *just* moved to 20.x and we want to give it some time to make sure we don't need to go back to the old server which is stuck at 14.x.