### PR TITLE
fixup! build(deps): bump @octokit/rest from 20.1.1 to 21.0.1

### DIFF
--- a/lib/github-client.js
+++ b/lib/github-client.js
@@ -1,6 +1,6 @@
 'use strict'
 
-async function getGithubClient() {
+async function getGithubClient () {
   const { Octokit } = await import('@octokit/rest')
 
   const githubClient = new Octokit({

--- a/lib/github-client.js
+++ b/lib/github-client.js
@@ -1,13 +1,17 @@
 'use strict'
 
-const { Octokit } = require('@octokit/rest')
+async function getGithubClient() {
+  const { Octokit } = await import('@octokit/rest')
 
-const githubClient = new Octokit({
-  auth: process.env.GITHUB_TOKEN || 'invalid-placeholder-token',
-  userAgent: 'Node.js GitHub Bot v1.0-beta',
-  request: {
-    timeout: 5 * 1000
-  }
-})
+  const githubClient = new Octokit({
+    auth: process.env.GITHUB_TOKEN || 'invalid-placeholder-token',
+    userAgent: 'Node.js GitHub Bot v1.0-beta',
+    request: {
+      timeout: 5 * 1000
+    }
+  })
 
-module.exports = githubClient
+  return githubClient
+}
+
+module.exports = getGithubClient()

--- a/lib/github-comment.js
+++ b/lib/github-comment.js
@@ -6,7 +6,7 @@ const githubClient = require('./github-client')
 
 exports.createPrComment = async function createPrComment ({ owner, repo, issue_number, logger }, body) {
   try {
-    await githubClient.issues.createComment({
+    await (await githubClient).issues.createComment({
       owner,
       repo,
       issue_number,

--- a/lib/jenkins-events.js
+++ b/lib/jenkins-events.js
@@ -66,7 +66,7 @@ module.exports = (app, events) => {
     res.end()
   })
 
-  app.emitJenkinsEvent = function emitJenkinsEvent (event, data, logger) {
+  app.emitJenkinsEvent = async function emitJenkinsEvent (event, data, logger) {
     const { identifier } = data
 
     // create unique logger which is easily traceable throughout the entire app
@@ -78,7 +78,7 @@ module.exports = (app, events) => {
     data.logger.info('Emitting Jenkins event')
     debug(data)
 
-    events.emit('jenkins', data)
+    await events.emit('jenkins', data)
     return events.emit(`jenkins.${event}`, data)
   }
 }

--- a/lib/node-repo.js
+++ b/lib/node-repo.js
@@ -22,7 +22,7 @@ async function removeLabelFromPR (options, label) {
   options.logger.debug('Trying to remove label: ' + label)
 
   try {
-    await githubClient.issues.removeLabel({
+    await (await githubClient).issues.removeLabel({
       owner: options.owner,
       repo: options.repo,
       issue_number: options.prId,
@@ -42,13 +42,13 @@ async function removeLabelFromPR (options, label) {
 }
 
 function getBotPrLabels (options, cb) {
-  githubClient.issues.listEvents({
+  githubClient.then(client => client.issues.listEvents({
     owner: options.owner,
     repo: options.repo,
     page: 1,
     per_page: 100, // we probably won't hit this
     issue_number: options.prId
-  }).then(res => {
+  })).then(res => {
     const events = res.data || []
     const ourLabels = []
 
@@ -86,7 +86,7 @@ function getCodeOwnersUrl (owner, repo, defaultBranch) {
 
 async function listFiles ({ owner, repo, prId, logger }) {
   try {
-    const response = await githubClient.pulls.listFiles({
+    const response = await (await githubClient).pulls.listFiles({
       owner,
       repo,
       pull_number: prId
@@ -100,7 +100,7 @@ async function listFiles ({ owner, repo, prId, logger }) {
 
 async function getDefaultBranch ({ owner, repo, logger }) {
   try {
-    const data = (await githubClient.repos.get({ owner, repo })).data || { }
+    const data = (await (await githubClient).repos.get({ owner, repo })).data || { }
 
     if (!data.default_branch) {
       logger.error(null, 'Could not determine default branch')

--- a/lib/push-jenkins-update.js
+++ b/lib/push-jenkins-update.js
@@ -78,12 +78,12 @@ function findPrInRef (gitRef) {
 }
 
 async function findLatestCommitInPr (options) {
-  const paginateOptions = githubClient.pulls.listCommits.endpoint.merge({
+  const paginateOptions = (await githubClient).pulls.listCommits.endpoint.merge({
     owner: options.owner,
     repo: options.repo,
     pull_number: options.pr
   })
-  const commitMetas = await githubClient.paginate(paginateOptions)
+  const commitMetas = await (await githubClient).paginate(paginateOptions)
 
   const lastCommitMeta = commitMetas.pop()
   const lastCommit = {
@@ -96,7 +96,7 @@ async function findLatestCommitInPr (options) {
 
 async function createGhStatus (options, logger) {
   try {
-    await githubClient.repos.createCommitStatus({
+    await (await githubClient).repos.createCommitStatus({
       owner: options.owner,
       repo: options.repo,
       sha: options.sha,

--- a/lib/push-jenkins-update.js
+++ b/lib/push-jenkins-update.js
@@ -31,7 +31,7 @@ function pushStarted (options, build, cb) {
     }
   }
 
-  findLatestCommitInPr(optsWithPr).then(latestCommit => {
+  return findLatestCommitInPr(optsWithPr).then(latestCommit => {
     const statusOpts = Object.assign({
       sha: latestCommit.sha,
       url: build.url,
@@ -40,7 +40,7 @@ function pushStarted (options, build, cb) {
       message: build.message || 'running tests'
     }, options)
 
-    createGhStatus(statusOpts, logger).then(cb).catch(cb)
+    return createGhStatus(statusOpts, logger).then(cb).catch(cb)
   }, err => {
     logger.error(err, 'Got error when retrieving GitHub commits for PR')
     return cb(err)

--- a/scripts/event-relay.js
+++ b/scripts/event-relay.js
@@ -7,7 +7,7 @@ async function handleJenkinsRelay (event) {
   const eventType = `jenkins.${identifier}.${event.event}`
   try {
     event.logger.debug(`Relaying ${eventType} to ${owner}/${repo}`)
-    await githubClient.repos.createDispatchEvent({
+    await (await githubClient).repos.createDispatchEvent({
       owner,
       repo,
       event_type: eventType,

--- a/scripts/jenkins-status.js
+++ b/scripts/jenkins-status.js
@@ -5,7 +5,7 @@ const pushJenkinsUpdate = require('../lib/push-jenkins-update')
 function handleJenkinsStart (event) {
   const { repo, owner } = event
 
-  pushJenkinsUpdate.pushStarted({
+  return pushJenkinsUpdate.pushStarted({
     owner,
     repo,
     logger: event.logger
@@ -19,7 +19,7 @@ function handleJenkinsStart (event) {
 function handleJenkinsStop (event) {
   const { repo, owner } = event
 
-  pushJenkinsUpdate.pushEnded({
+  return pushJenkinsUpdate.pushEnded({
     owner,
     repo,
     logger: event.logger


### PR DESCRIPTION
Require of octokit migrated to `await import` to accommodate chango to ESM-only