### PR TITLE
chore: update fetch-mock from 11.1.5 to 12.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       },
       "devDependencies": {
         "eventsource": "^2.0.2",
-        "fetch-mock": "^11.1.5",
+        "fetch-mock": "^12.0.2",
         "nock": "^13.5.5",
         "nodemon": "^3.1.7",
         "standard": "^17.1.2",
@@ -4086,24 +4086,20 @@
       }
     },
     "node_modules/fetch-mock": {
-      "version": "11.1.5",
-      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-11.1.5.tgz",
-      "integrity": "sha512-KHmZDnZ1ry0pCTrX4YG5DtThHi0MH+GNI9caESnzX/nMJBrvppUHMvLx47M0WY9oAtKOMiPfZDRpxhlHg89BOA==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-12.0.2.tgz",
+      "integrity": "sha512-9KVq/Scz06A+ThORLA/J/EACiPzLdSn6DeLV61hni57kd3DXhQVCtkpj4LgwES+8osEVEfcqA6LwdSX2FYVK7w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/glob-to-regexp": "^0.4.4",
         "dequal": "^2.0.3",
         "glob-to-regexp": "^0.4.1",
-        "is-subset": "^0.1.1",
+        "is-subset-of": "^3.1.10",
         "regexparam": "^3.0.0"
       },
       "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-fetch": {
-          "optional": true
-        }
+        "node": ">=18.11.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -5346,11 +5342,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-subset": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-      "integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
-      "dev": true
+    "node_modules/is-subset-of": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/is-subset-of/-/is-subset-of-3.1.10.tgz",
+      "integrity": "sha512-avvaYgVmYWyaZ1NDFiv4y9JGkrE2je3op1Po4VYKKJKR8H2qVPsg1GZuuXl5elCTxTlwAIsrAjWAs4BVrISFRw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "typedescriptor": "3.0.2"
+      }
     },
     "node_modules/is-symbol": {
       "version": "1.0.4",
@@ -8524,6 +8525,14 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/typedescriptor": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/typedescriptor/-/typedescriptor-3.0.2.tgz",
+      "integrity": "sha512-hyVbaCUd18UiXk656g/imaBLMogpdijIEpnhWYrSda9rhvO4gOU16n2nh7xG5lv/rjumnZzGOdz0CEGTmFe0fQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.5.4",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "eventsource": "^2.0.2",
-    "fetch-mock": "^11.1.5",
+    "fetch-mock": "^12.0.2",
     "nock": "^13.5.5",
     "nodemon": "^3.1.7",
     "standard": "^17.1.2",

--- a/test/integration/event-relay-to-github-actions.test.js
+++ b/test/integration/event-relay-to-github-actions.test.js
@@ -13,7 +13,8 @@ eventRelay(app, events)
 tap.test('Sends POST requests to https://api.github.com/repos/nodejs/<repo>/dispatches', (t) => {
   const jenkinsPayload = readFixture('success-payload.json')
 
-  fetchMock.mock('https://api.github.com/repos/nodejs/node/dispatches', 204)
+  fetchMock.mockGlobal()
+  fetchMock.route('https://api.github.com/repos/nodejs/node/dispatches', 204)
 
   t.plan(2)
 
@@ -23,6 +24,6 @@ tap.test('Sends POST requests to https://api.github.com/repos/nodejs/<repo>/disp
     .expect(200)
     .end((err, res) => {
       t.equal(err, null)
-      t.equal(fetchMock.done(), true)
+      t.equal(fetchMock.callHistory.called(), true)
     })
 })

--- a/test/integration/push-jenkins-update.test.js
+++ b/test/integration/push-jenkins-update.test.js
@@ -9,6 +9,7 @@ import readFixture from '../read-fixture.js'
 import jenkinsStatus from '../../scripts/jenkins-status.js'
 
 fetchMock.config.overwriteRoutes = true
+fetchMock.mockGlobal()
 
 jenkinsStatus(app, events)
 
@@ -18,7 +19,7 @@ tap.test('Sends POST requests to https://api.github.com/repos/nodejs/node/status
   const listCommitsUrl = setupListCommitsMock('node')
 
   const url = 'https://api.github.com/repos/nodejs/node/statuses/8a5fec2a6bade91e544a30314d7cf21f8a200de1'
-  fetchMock.mock({ url, method: 'POST' }, 201)
+  fetchMock.route({ url, method: 'POST' }, 201)
 
   t.plan(3)
 
@@ -28,8 +29,8 @@ tap.test('Sends POST requests to https://api.github.com/repos/nodejs/node/status
     .expect(200)
     .end((err, res) => {
       t.equal(err, null)
-      t.equal(fetchMock.done(url), true)
-      t.equal(fetchMock.done(listCommitsUrl), true)
+      t.equal(fetchMock.callHistory.called(url), true)
+      t.equal(fetchMock.callHistory.called(listCommitsUrl), true)
     })
 })
 
@@ -39,7 +40,7 @@ tap.test('Allows repository name to be provided with URL parameter when pushing 
   const listCommitsUrl = setupListCommitsMock('citgm')
 
   const url = 'https://api.github.com/repos/nodejs/citgm/statuses/8a5fec2a6bade91e544a30314d7cf21f8a200de1'
-  fetchMock.mock({ url, method: 'POST' }, 201)
+  fetchMock.route({ url, method: 'POST' }, 201)
 
   t.plan(3)
 
@@ -49,8 +50,8 @@ tap.test('Allows repository name to be provided with URL parameter when pushing 
     .expect(200)
     .end((err, res) => {
       t.equal(err, null)
-      t.equal(fetchMock.done(url), true)
-      t.equal(fetchMock.done(listCommitsUrl), true)
+      t.equal(fetchMock.callHistory.called(url), true)
+      t.equal(fetchMock.callHistory.called(listCommitsUrl), true)
     })
 })
 
@@ -60,7 +61,7 @@ tap.test('Allows repository name to be provided with URL parameter when pushing 
   const listCommitsUrl = setupListCommitsMock('citgm')
 
   const url = 'https://api.github.com/repos/nodejs/citgm/statuses/8a5fec2a6bade91e544a30314d7cf21f8a200de1'
-  fetchMock.mock({ url, method: 'POST' }, 201)
+  fetchMock.route({ url, method: 'POST' }, 201)
 
   t.plan(3)
 
@@ -70,8 +71,8 @@ tap.test('Allows repository name to be provided with URL parameter when pushing 
     .expect(200)
     .end((err, res) => {
       t.equal(err, null)
-      t.equal(fetchMock.done(url), true)
-      t.equal(fetchMock.done(listCommitsUrl), true)
+      t.equal(fetchMock.callHistory.called(url), true)
+      t.equal(fetchMock.callHistory.called(listCommitsUrl), true)
     })
 })
 
@@ -87,7 +88,7 @@ tap.test('Forwards payload provided in incoming POST to GitHub status API', (t) 
     description: 'tests passed',
     target_url: 'https://ci.nodejs.org/job/node-test-commit-osx/3157/'
   }
-  fetchMock.mock({ url, method: 'POST', body }, 201)
+  fetchMock.route({ url, method: 'POST', body }, 201)
 
   t.plan(3)
 
@@ -97,8 +98,8 @@ tap.test('Forwards payload provided in incoming POST to GitHub status API', (t) 
     .expect(200)
     .end((err, res) => {
       t.equal(err, null)
-      t.equal(fetchMock.done(url), true)
-      t.equal(fetchMock.done(listCommitsUrl), true)
+      t.equal(fetchMock.callHistory.called(url), true)
+      t.equal(fetchMock.callHistory.called(listCommitsUrl), true)
     })
 })
 
@@ -107,11 +108,11 @@ tap.test('Posts a CI comment in the related PR when Jenkins build is named node-
 
   const url = 'https://api.github.com/repos/nodejs/node/issues/12345/comments'
   const body = { body: 'CI: https://ci.nodejs.org/job/node-test-pull-request/21633/' }
-  fetchMock.mock({ url, method: 'POST', body }, 200)
+  fetchMock.route({ url, method: 'POST', body }, 200)
 
   // we don't care about asserting the scopes below, just want to stop the requests from actually being sent
   setupListCommitsMock('node')
-  fetchMock.mock(
+  fetchMock.route(
     {
       url: 'https://api.github.com/repos/nodejs/node/statuses/8a5fec2a6bade91e544a30314d7cf21f8a200de1',
       method: 'POST'
@@ -124,7 +125,7 @@ tap.test('Posts a CI comment in the related PR when Jenkins build is named node-
     .send(fixture)
     .expect(200)
     .end((err, res) => {
-      t.equal(fetchMock.done(url), true)
+      t.equal(fetchMock.callHistory.called(url), true)
       t.equal(err, null)
     })
 })
@@ -135,11 +136,11 @@ tap.test('Posts a CI comment in the related PR when Jenkins build is named node-
 
   const url = 'https://api.github.com/repos/nodejs/node/issues/12345/comments'
   const body = { body: 'Lite-CI: https://ci.nodejs.org/job/node-test-pull-request/21633/' }
-  fetchMock.mock({ url, body, method: 'POST' }, 200)
+  fetchMock.route({ url, body, method: 'POST' }, 200)
 
   // we don't care about asserting the scopes below, just want to stop the requests from actually being sent
   setupListCommitsMock('node')
-  fetchMock.mock(
+  fetchMock.route(
     {
       url: 'https://api.github.com/repos/nodejs/node/statuses/8a5fec2a6bade91e544a30314d7cf21f8a200de1',
       method: 'POST'
@@ -152,7 +153,7 @@ tap.test('Posts a CI comment in the related PR when Jenkins build is named node-
     .send(fixture)
     .expect(200)
     .end((err, res) => {
-      t.equal(fetchMock.done(url), true)
+      t.equal(fetchMock.callHistory.called(url), true)
       t.equal(err, null)
     })
 })
@@ -161,7 +162,7 @@ tap.test('Responds with 400 / "Bad request" when incoming request has invalid pa
   const fixture = readFixture('invalid-payload.json')
 
   // don't care about the results, just want to prevent any HTTP request ever being made
-  fetchMock.mock('https://api.github.com', 200)
+  fetchMock.route('https://api.github.com', 200)
 
   t.plan(1)
 
@@ -178,7 +179,7 @@ tap.test('Responds with 400 / "Bad request" when build started status update is 
   const fixture = readFixture('jenkins-staging-failure-payload.json')
 
   // don't care about the results, just want to prevent any HTTP request ever being made
-  fetchMock.mock('https://api.github.com', 200)
+  fetchMock.route('https://api.github.com', 200)
 
   t.plan(1)
 
@@ -195,7 +196,7 @@ tap.test('Responds with 400 / "Bad request" when build ended status update is no
   const fixture = readFixture('jenkins-staging-failure-payload.json')
 
   // don't care about the results, just want to prevent any HTTP request ever being made
-  fetchMock.mock('https://api.github.com/', 200)
+  fetchMock.route('https://api.github.com/', 200)
 
   t.plan(1)
 
@@ -212,7 +213,7 @@ tap.test('Responds with 400 / "Bad request" when incoming providing invalid repo
   const fixture = readFixture('pending-payload.json')
 
   // don't care about the results, just want to prevent any HTTP request ever being made
-  fetchMock.mock('https://api.github.com/', 200)
+  fetchMock.route('https://api.github.com/', 200)
 
   t.plan(1)
 
@@ -229,6 +230,6 @@ function setupListCommitsMock (repoName) {
   const commitsResponse = readFixture('pr-commits.json')
   const url = `https://api.github.com/repos/nodejs/${repoName}/pulls/12345/commits`
 
-  fetchMock.mock(url, commitsResponse)
+  fetchMock.route(url, commitsResponse)
   return url
 }

--- a/test/unit/node-repo.test.js
+++ b/test/unit/node-repo.test.js
@@ -6,6 +6,8 @@ import * as nodeRepo from '../../lib/node-repo.js'
 import logger from '../../lib/logger.js'
 import readFixture from '../read-fixture.js'
 
+fetchMock.mockGlobal()
+
 tap.test('getBotPrLabels(): returns labels added by nodejs-github-bot', (t) => {
   const events = readFixture('pull-request-events.json')
 
@@ -14,12 +16,12 @@ tap.test('getBotPrLabels(): returns labels added by nodejs-github-bot', (t) => {
   const prId = '1'
   const urlPattern = `glob:https://api.github.com/repos/${owner}/${repo}/issues/${prId}/events?*`
 
-  fetchMock.mock(urlPattern, events.data)
+  fetchMock.route(urlPattern, events.data)
   t.plan(2)
 
   nodeRepo.getBotPrLabels({ owner, repo, prId }, (_, labels) => {
     t.same(labels, ['testlabel'])
-    t.equal(fetchMock.done(urlPattern), true)
+    t.equal(fetchMock.callHistory.called(urlPattern), true)
   })
 })
 
@@ -31,7 +33,7 @@ tap.test('getBotPrLabels(): returns net labels added/removed by nodejs-github-bo
   const prId = '2'
   const urlPattern = `glob:https://api.github.com/repos/${owner}/${repo}/issues/${prId}/events?*`
 
-  fetchMock.mock(
+  fetchMock.route(
     urlPattern,
     events.data
   )
@@ -39,7 +41,7 @@ tap.test('getBotPrLabels(): returns net labels added/removed by nodejs-github-bo
 
   nodeRepo.getBotPrLabels({ owner, repo, prId }, (_, labels) => {
     t.same(labels, [])
-    t.equal(fetchMock.done(urlPattern), true)
+    t.equal(fetchMock.callHistory.called(urlPattern), true)
   })
 })
 
@@ -50,7 +52,7 @@ tap.test('removeLabelFromPR(): should remove label', async (t) => {
   const label = '3'
   const urlPattern = `https://api.github.com/repos/${owner}/${repo}/issues/${prId}/labels/${label}`
 
-  fetchMock.mock(
+  fetchMock.route(
     urlPattern,
     200
   )
@@ -58,5 +60,5 @@ tap.test('removeLabelFromPR(): should remove label', async (t) => {
 
   const response = await nodeRepo.removeLabelFromPR({ owner, repo, prId, logger }, label)
   t.same(label, response)
-  t.equal(fetchMock.done(urlPattern), true)
+  t.equal(fetchMock.callHistory.called(urlPattern), true)
 })

--- a/test/unit/push-jenkins-update.test.js
+++ b/test/unit/push-jenkins-update.test.js
@@ -14,7 +14,9 @@ tap.test('findLatestCommitInPr: paginates results when more than 100 commits in 
   const repo = 'node'
   const pr = 9745
 
-  const firstPageScope = fetchMock.mock(
+  fetchMock.mockGlobal()
+
+  const firstPageScope = fetchMock.route(
     `https://api.github.com/repos/${owner}/${repo}/pulls/${pr}/commits`,
     {
       body: commitsFixturePage1,
@@ -24,7 +26,7 @@ tap.test('findLatestCommitInPr: paginates results when more than 100 commits in 
     }
   )
 
-  const secondPageScope = fetchMock.mock(
+  const secondPageScope = fetchMock.route(
     `https://api.github.com/repositories/27193779/pulls/${pr}/commits?page=2`,
     {
       body: commitsFixturePage2,
@@ -34,7 +36,7 @@ tap.test('findLatestCommitInPr: paginates results when more than 100 commits in 
     }
   )
 
-  const thirdPageScope = fetchMock.mock(
+  const thirdPageScope = fetchMock.route(
     `https://api.github.com/repositories/27193779/pulls/${pr}/commits?page=3`,
     {
       body: commitsFixturePage3,
@@ -43,7 +45,8 @@ tap.test('findLatestCommitInPr: paginates results when more than 100 commits in 
       }
     }
   )
-  const fourthPageScope = fetchMock.mock(
+
+  const fourthPageScope = fetchMock.route(
     `https://api.github.com/repositories/27193779/pulls/${pr}/commits?page=4`,
     {
       body: commitsFixturePage4,
@@ -57,8 +60,8 @@ tap.test('findLatestCommitInPr: paginates results when more than 100 commits in 
 
   const commit = await findLatestCommitInPr({ owner, repo, pr })
   t.equal(commit.sha, 'c1aa949064892dbe693750686c06f4ad5673e577')
-  firstPageScope.done()
-  secondPageScope.done()
-  thirdPageScope.done()
-  fourthPageScope.done()
+  firstPageScope.callHistory.called()
+  secondPageScope.callHistory.called()
+  thirdPageScope.callHistory.called()
+  fourthPageScope.callHistory.called()
 })


### PR DESCRIPTION
The API has changed to this update requires updates to our tests.